### PR TITLE
Parameterize DB connection; compose reads ENV; JWT via ConfigurationProperties (closes #2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     container_name: vire-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: vire
+      POSTGRES_DB: ${DB_NAME:-vire}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
-      - "5432:5432"
+      - "${PG_HOST_PORT:-5432}:5432"
     volumes:
       - vire_db_data:/var/lib/postgresql/data
     healthcheck:
@@ -31,6 +31,9 @@ services:
     ports:
       - "8080:8080"
     environment:
+      DB_NAME: ${DB_NAME:-vire}
+      DB_PORT: 5432
+      DB_HOST: db
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
-      JWT_EXPIRATION: ${JWT_EXPIRATION:-3600000}
+      JWT_EXPIRATION: ${JWT_EXPIRATION:-1h}
     depends_on:
       db:
         condition: service_healthy

--- a/src/main/java/com/vire/virebackend/ViReBackendApplication.java
+++ b/src/main/java/com/vire/virebackend/ViReBackendApplication.java
@@ -1,9 +1,12 @@
 package com.vire.virebackend;
 
+import com.vire.virebackend.config.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan(basePackageClasses = {JwtProperties.class})
 public class ViReBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/vire/virebackend/config/JwtProperties.java
+++ b/src/main/java/com/vire/virebackend/config/JwtProperties.java
@@ -1,0 +1,25 @@
+package com.vire.virebackend.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+@Validated
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        @NotBlank String secret,
+        @NotNull @DurationMin(millis = 1) Duration expiration
+) {
+    @PostConstruct
+    void validateSecret() {
+        if (secret.getBytes(StandardCharsets.UTF_8).length < 64) {
+            throw new IllegalStateException("jwt.secret must be >= 64 bytes for HS512");
+        }
+    }
+}

--- a/src/main/java/com/vire/virebackend/security/JwtService.java
+++ b/src/main/java/com/vire/virebackend/security/JwtService.java
@@ -1,11 +1,11 @@
 package com.vire.virebackend.security;
 
+import com.vire.virebackend.config.JwtProperties;
 import com.vire.virebackend.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -17,21 +17,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class JwtService {
 
-    @Value("${jwt.secret}")
-    private String secret;
-
-    @Value("${jwt.expiration}")
-    private Long jwtExpiration;
+    private final JwtProperties jwtProperties;
 
     private SecretKey getSignKey() {
-        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        return Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
     }
 
     public String generateToken(User user) {
         return Jwts.builder()
                 .subject(user.getId().toString())
                 .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().toMillis()))
                 .signWith(getSignKey(), Jwts.SIG.HS512)
                 .compact();
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/vire
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:vire}
 
   jpa:
     show-sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:postgresql://db:5432/vire
+    url: jdbc:postgresql://db:5432/${DB_NAME:vire}


### PR DESCRIPTION
## What’s Changed

- Parameterized DB connection via env placeholders in application-*.yml (DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD)
- Dev compose: backend reads DB_HOST=db и DB_PORT=5432; expose DB ${PG_HOST_PORT:-5432}:5432
- JWT changed to @ConfigurationProperties (JwtProperties); expiration - Duration ( 1h, 60m, 3600000 e.g.)

## Why

- Consistent configuration via environment variables for both ide/dev and compose
- Predictable networking in Compose: services talk over db:5432; host port is configurable via PG_HOST_PORT
- Type safe and validated JWT settings; clearer time configuration using Duration

## Additional Notes

- Closes #2 
- In application-prod.yml, the datasource URL is fixed to db:5432 - appropriate when production runs in the same Compose network. If the DB is external, override via SPRING_DATASOURCE_URL or DB_HOST/DB_PORT.
- PG_HOST_PORT controls only host exposure; container to container traffic always uses the container port 5432.
