### PR TITLE
Docker profiles and actuator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN ./mvnw -B package -DskipTests
 FROM eclipse-temurin:24-jre-alpine AS runtime
 WORKDIR /app
 ENV SPRING_PROFILES_ACTIVE=prod
+RUN apk add --no-cache curl
 COPY --from=build /app/target/*-SNAPSHOT.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: postgres:17-alpine
     container_name: vire-postgres
     restart: unless-stopped
+    profiles: [ dev, "" ]
     environment:
       POSTGRES_DB: ${DB_NAME:-vire}
       POSTGRES_USER: ${DB_USERNAME}
@@ -28,9 +29,12 @@ services:
       dockerfile: Dockerfile
       target: runtime
     container_name: vire-backend
+    restart: unless-stopped
+    profiles: [ "" ]
     ports:
       - "8080:8080"
     environment:
+      SPRING_PROFILES_ACTIVE: prod
       DB_NAME: ${DB_NAME:-vire}
       DB_PORT: 5432
       DB_HOST: db
@@ -41,6 +45,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-fsS", "--connect-timeout", "1", "--max-time", "2", "http://localhost:8081/actuator/health/readiness" ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 25s
     logging:
       driver: json-file
       options:

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <version>3.1.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.5.4</version>
+        </dependency>
+
         <!-- JSON Web Token -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.vire.virebackend.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,6 +15,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AndRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -27,7 +31,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain appSecurity(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                                 "/api/auth/register",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html"
+                                "/swagger-ui.html",
+                                "/actuator/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ jwt:
   expiration: ${JWT_EXPIRATION:3600000}
 
 management:
+  server:
+    port: 8081
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,13 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION:3600000}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+  endpoint:
+    health:
+      probes:
+        enabled: true


### PR DESCRIPTION
## What’s Changed

- Added Docker Compose profiles:
  - Default (prod) -> backend + db
  - Dev -> db only
- Configured backend healthcheck using /actuator/health/readiness on port 8081

## Why

To simplify environment startup and ensure consistent behavior between dev and prod. Healthchecks improve container orchestration reliability by ensuring the app is ready before being marked healthy.

## How to Test

1. Prod profile (default)
`docker compose up -d`
`docker ps --format 'table {{.Names}}\t{{.Status}}'`
Expected: vire-postgres = healthy, vire-backend = healthy

2. Dev profile
`docker compose --profile dev up -d`
`docker ps --format 'table {{.Names}}\t{{.Status}}'`
Expected: Only vire-postgres container running and healthy

## Additional Notes

- Closes #3
- Actuator is running on 8081 port and is available only inside container for healthcheck
