### PR TITLE
Global exception handler

### DIFF
--- a/src/main/java/com/vire/virebackend/ViReBackendApplication.java
+++ b/src/main/java/com/vire/virebackend/ViReBackendApplication.java
@@ -1,12 +1,13 @@
 package com.vire.virebackend;
 
 import com.vire.virebackend.config.JwtProperties;
+import com.vire.virebackend.problem.ProblemProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
-@ConfigurationPropertiesScan(basePackageClasses = {JwtProperties.class})
+@ConfigurationPropertiesScan(basePackageClasses = {JwtProperties.class, ProblemProperties.class})
 public class ViReBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
@@ -1,0 +1,10 @@
+package com.vire.virebackend.controller.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+}

--- a/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
@@ -1,10 +1,66 @@
 package com.vire.virebackend.controller.advice;
 
+import com.vire.virebackend.problem.ProblemFactory;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.*;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private final ProblemFactory problemFactory;
+
+    // 400 @Valid body
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleInvalidBody(MethodArgumentNotValidException exception) {
+        Map<String, List<String>> errors = new LinkedHashMap<>();
+        for (FieldError fe : exception.getBindingResult().getFieldErrors()) {
+            errors.computeIfAbsent(fe.getField(), i -> new ArrayList<>())
+                    .add(Objects.toString(fe.getDefaultMessage(), "Invalid value"));
+        }
+        return problemFactory.validation(errors);
+    }
+
+    // 400 @Validated params/path + JSON parsing
+    @ExceptionHandler({ConstraintViolationException.class, HttpMessageNotReadableException.class})
+    public ProblemDetail handleBadRequest(Exception exception) {
+        if (exception instanceof ConstraintViolationException cve) {
+            Map<String, List<String>> errors = new LinkedHashMap<>();
+            for (ConstraintViolation<?> v : cve.getConstraintViolations()) {
+                var field = v.getPropertyPath() != null ? v.getPropertyPath().toString() : "param";
+                errors.computeIfAbsent(field, i -> new ArrayList<>()).add(v.getMessage());
+            }
+
+            return problemFactory.validation(errors);
+        }
+
+        return problemFactory.badRequest("Malformed or invalid request");
+    }
+
+    // 404 not found
+    @ExceptionHandler({EntityNotFoundException.class, NoSuchElementException.class})
+    public ProblemDetail handleNotFound(RuntimeException exception) {
+        return problemFactory.notFound("Resource not found");
+    }
+
+    // 500 others
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleAny(Exception exception) {
+        var incidentId = UUID.randomUUID();
+        log.error("Unhandled exception, incidentId={}", incidentId, exception);
+
+        return problemFactory.internal(incidentId);
+    }
 }

--- a/src/main/java/com/vire/virebackend/problem/ProblemFactory.java
+++ b/src/main/java/com/vire/virebackend/problem/ProblemFactory.java
@@ -1,0 +1,80 @@
+package com.vire.virebackend.problem;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemFactory {
+
+    private final ProblemTypeResolver resolver;
+
+    public ProblemDetail of(HttpStatus status, ProblemType type, String title, String detail) {
+        var problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setType(resolver.uri(type));
+        problemDetail.setTitle(title);
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+        return problemDetail;
+    }
+
+    public ProblemDetail validation(Map<String, ?> errors) {
+        var problemDetail = of(
+                HttpStatus.BAD_REQUEST,
+                ProblemType.VALIDATION,
+                "Validation failed",
+                "One or more fields are invalid");
+        problemDetail.setProperty("error", errors);
+
+        return problemDetail;
+    }
+
+    public ProblemDetail internal(UUID incidentId) {
+        var problemDetail = of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ProblemType.INTERNAL,
+                "Internal server error",
+                "If the problem persists, contact support and mention incidentId");
+        problemDetail.setProperty("incidentId", incidentId != null ? incidentId : UUID.randomUUID());
+
+        return problemDetail;
+    }
+
+    public ProblemDetail badRequest(String detail) {
+        return of(
+                HttpStatus.BAD_REQUEST,
+                ProblemType.BAD_REQUEST,
+                "Bad request",
+                detail != null ? detail : "Malformed or invalid request");
+    }
+
+    public ProblemDetail unauthorized() {
+        return of(
+                HttpStatus.UNAUTHORIZED,
+                ProblemType.AUTHENTICATION,
+                "Unauthorized",
+                "Authentication required or failed");
+    }
+
+    public ProblemDetail forbidden() {
+        return of(
+                HttpStatus.FORBIDDEN,
+                ProblemType.FORBIDDEN,
+                "Forbidden",
+                "You don't have permission to perform this action");
+    }
+
+    public ProblemDetail notFound(String detail) {
+        return of(
+                HttpStatus.NOT_FOUND,
+                ProblemType.NOT_FOUND,
+                "Not found",
+                detail != null ? detail : "Resource not found");
+    }
+}

--- a/src/main/java/com/vire/virebackend/problem/ProblemFactory.java
+++ b/src/main/java/com/vire/virebackend/problem/ProblemFactory.java
@@ -30,7 +30,7 @@ public class ProblemFactory {
                 ProblemType.VALIDATION,
                 "Validation failed",
                 "One or more fields are invalid");
-        problemDetail.setProperty("error", errors);
+        problemDetail.setProperty("errors", errors);
 
         return problemDetail;
     }

--- a/src/main/java/com/vire/virebackend/problem/ProblemProperties.java
+++ b/src/main/java/com/vire/virebackend/problem/ProblemProperties.java
@@ -1,0 +1,19 @@
+package com.vire.virebackend.problem;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.net.URI;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "problem")
+public class ProblemProperties {
+
+    /**
+     * Base URI for ProblemDetail.type (must end with /).
+     * Only used if not set in application.yml
+     */
+    private URI baseUri = URI.create("https://vire.dev/problems/");
+}

--- a/src/main/java/com/vire/virebackend/problem/ProblemType.java
+++ b/src/main/java/com/vire/virebackend/problem/ProblemType.java
@@ -1,0 +1,21 @@
+package com.vire.virebackend.problem;
+
+public enum ProblemType {
+
+    VALIDATION("validation-error"),
+    BAD_REQUEST("bad-request"),
+    AUTHENTICATION("authentication"),
+    FORBIDDEN("forbidden"),
+    NOT_FOUND("not-found"),
+    INTERNAL("internal");
+
+    private final String slug;
+
+    ProblemType(String slug) {
+        this.slug = slug;
+    }
+
+    public String slug() {
+        return slug;
+    }
+}

--- a/src/main/java/com/vire/virebackend/problem/ProblemTypeResolver.java
+++ b/src/main/java/com/vire/virebackend/problem/ProblemTypeResolver.java
@@ -1,0 +1,17 @@
+package com.vire.virebackend.problem;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemTypeResolver {
+
+    private final ProblemProperties problemProperties;
+
+    public URI uri(ProblemType type) {
+        return problemProperties.getBaseUri().resolve(type.slug());
+    }
+}

--- a/src/main/java/com/vire/virebackend/security/handler/SecurityProblemHandlers.java
+++ b/src/main/java/com/vire/virebackend/security/handler/SecurityProblemHandlers.java
@@ -1,4 +1,4 @@
-package com.vire.virebackend.security.handlers;
+package com.vire.virebackend.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vire.virebackend.problem.ProblemFactory;

--- a/src/main/java/com/vire/virebackend/security/handlers/SecurityProblemHandlers.java
+++ b/src/main/java/com/vire/virebackend/security/handlers/SecurityProblemHandlers.java
@@ -1,0 +1,52 @@
+package com.vire.virebackend.security.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vire.virebackend.problem.ProblemFactory;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityProblemHandlers {
+
+    private final ProblemFactory problemFactory;
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Prepare http response with error description in RFC 7807 format
+     *
+     * @param response      injectable response object
+     * @param problemDetail
+     * @param status
+     * @throws IOException
+     */
+    private void write(HttpServletResponse response, ProblemDetail problemDetail, int status) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/problem+json");
+        objectMapper.writeValue(response.getOutputStream(), problemDetail);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint handleAuthenticationEntryPoint() {
+        return (request, response, authException) -> {
+            var problemDetail = problemFactory.unauthorized();
+            write(response, problemDetail, HttpServletResponse.SC_UNAUTHORIZED);
+        };
+    }
+
+    @Bean
+    public AccessDeniedHandler handleAccessDenied() {
+        return (request, response, accessDeniedException) -> {
+            var problemDetail = problemFactory.forbidden();
+            write(response, problemDetail, HttpServletResponse.SC_FORBIDDEN);
+        };
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,6 @@ management:
     health:
       probes:
         enabled: true
+
+problem:
+  base-uri: "https://vire.dev/problems/"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration: ${JWT_EXPIRATION:3600000}
+  expiration: ${JWT_EXPIRATION:1h}
 
 management:
   server:
@@ -40,4 +40,4 @@ management:
         enabled: true
 
 problem:
-  base-uri: "https://vire.dev/problems/"
+  base-uri: https://vire.dev/problems/

--- a/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
+++ b/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
@@ -1,0 +1,120 @@
+package com.vire.virebackend.controller.advice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vire.virebackend.controller.AuthController;
+import com.vire.virebackend.controller.UserController;
+import com.vire.virebackend.problem.ProblemFactory;
+import com.vire.virebackend.problem.ProblemProperties;
+import com.vire.virebackend.problem.ProblemTypeResolver;
+import com.vire.virebackend.repository.UserRepository;
+import com.vire.virebackend.security.JwtAuthenticationFilter;
+import com.vire.virebackend.security.JwtService;
+import com.vire.virebackend.security.SecurityConfig;
+import com.vire.virebackend.security.handler.SecurityProblemHandlers;
+import com.vire.virebackend.service.AuthService;
+import com.vire.virebackend.service.UserService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = {
+        AuthController.class,
+        UserController.class
+})
+@Import({
+        GlobalExceptionHandler.class,
+        SecurityProblemHandlers.class,
+        SecurityConfig.class,
+        ProblemFactory.class,
+        ProblemTypeResolver.class,
+        ProblemDetailWebTest.TestErrorConfig.class,
+        ProblemDetailWebTest.Mocks.class
+})
+class ProblemDetailWebTest {
+
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    ObjectMapper om;
+
+    @Test
+    void register_invalidPayload_returns400_problemDetail() throws Exception {
+        var body = Map.of("email", "not-an-email", "password", "123");
+
+        mvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(header().string("Content-Type", Matchers.containsString("application/problem+json")))
+                .andExpect(jsonPath("$.title").value("Validation failed"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.type").value("https://vire.dev/problems/validation-error"))
+                .andExpect(jsonPath("$.errors").exists());
+    }
+
+    @Test
+    void me_withoutToken_returns401_problemDetail() throws Exception {
+        mvc.perform(get("/api/user/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string("Content-Type", Matchers.containsString("application/problem+json")))
+                .andExpect(jsonPath("$.title").value("Unauthorized"))
+                .andExpect(jsonPath("$.status").value(401));
+    }
+
+    @TestConfiguration
+    @EnableConfigurationProperties(ProblemProperties.class)
+    static class TestErrorConfig {
+        @Bean
+        ProblemProperties problemProperties() {
+            var p = new ProblemProperties();
+            p.setBaseUri(URI.create("https://vire.dev/problems/"));
+            return p;
+        }
+    }
+
+    @TestConfiguration
+    static class Mocks {
+        @Bean
+        AuthService authService() {
+            return Mockito.mock(AuthService.class);
+        }
+
+        @Bean
+        UserService userService() {
+            return Mockito.mock(UserService.class);
+        }
+
+        @Bean
+        com.vire.virebackend.security.JwtService jwtService() {
+            return Mockito.mock(JwtService.class);
+        }
+
+        @Bean
+        com.vire.virebackend.repository.UserRepository userRepository() {
+            return Mockito.mock(UserRepository.class);
+        }
+
+        @Bean
+        JwtAuthenticationFilter jwtAuthenticationFilter(
+                JwtService jwtService,
+                UserRepository userRepository
+        ) {
+            return new JwtAuthenticationFilter(jwtService, userRepository);
+        }
+    }
+}


### PR DESCRIPTION
## What’s Changed

- Unified error format with ProblemDetail (RFC7807)
- Global handler for 400/404/500 and security handlers for 401/403
- Tests for invalid registration (400) and unauthorized (401)

## Why

- Consistent, readable errors
- Ensure internal errors are not returned as 403

## How to Test

- See test cases; try manual requests as described

## Additional Notes

- Closes #1 
