### PR TITLE
Dto validation issue 4

### DIFF
--- a/src/main/java/com/vire/virebackend/dto/auth/LoginRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/auth/LoginRequest.java
@@ -3,14 +3,17 @@ package com.vire.virebackend.dto.auth;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "Login request")
 public record LoginRequest(
         @NotBlank
         @Email
+        @Size(max = 255)
         String email,
 
         @NotBlank
+        @Size(min = 8, max = 255)
         String password
 ) {
 }

--- a/src/main/java/com/vire/virebackend/dto/auth/RegisterRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/auth/RegisterRequest.java
@@ -3,15 +3,19 @@ package com.vire.virebackend.dto.auth;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "Request for registration")
 public record RegisterRequest(
+        @NotBlank
         @Size(min = 3, max = 30)
+        @Pattern(regexp = "^[A-Za-z0-9._-]+$")
         String username,
 
         @Email
         @NotBlank
+        @Size(max = 255)
         String email,
 
         @NotBlank

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,14 @@ spring:
     enabled: true
     change-log: classpath:db/changelog/master.xml
 
+  mvc:
+    problemdetails:
+      enabled: true
+
+server:
+  error:
+    include-binding-errors: always
+
 jwt:
   secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION:1h}


### PR DESCRIPTION
## What’s Changed

- Added stricter Bean Validation constraints to auth DTOs

## Why

- Ensure predictable validation and developer‑friendly error payloads
- Align error format with RFC 7807 and keep consistency across endpoints

## How to Test

- POST /api/auth/login with empty email -> 400
- POST /api/auth/register with username="bad name" -> 400
- Check valid requests (200/201)

## Additional Notes

- Closes #4