### PR TITLE
OpenApi bearer auth scheme

### DIFF
--- a/src/main/java/com/vire/virebackend/config/OpenApiConfig.java
+++ b/src/main/java/com/vire/virebackend/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.vire.virebackend.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "ViRe Backend API", version = "v1")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/vire/virebackend/controller/UserController.java
+++ b/src/main/java/com/vire/virebackend/controller/UserController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/user")
 @RequiredArgsConstructor
 @Tag(name = "Users")
+@SecurityRequirement(name = "bearerAuth")
 public class UserController {
 
     private final UserService userService;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,8 @@ management:
 
 problem:
   base-uri: https://vire.dev/problems/
+
+springdoc:
+  swagger-ui:
+    display-request-duration: true
+    display-operation-id: true


### PR DESCRIPTION
## What’s Changed

- Added OpenAPI Bearer JWT security scheme ("bearerAuth")
- Marked secured endpoints to require authorization via @ SecurityRequirement
- Enabled request duration and id in Swagger UI

## Why

- Enable login via Swagger UI and send JWT in Authorization header
- Clearly indicate which endpoints are protected in API docs

## How to Test

1. Open /swagger-ui.html
2. Call POST /api/auth/login to get a JWT
3. Click **Authorize**, pick bearerAuth, paste the token
4. Call a protected endpoint (e.g., /api/user/me) - should return 200 with additional info
5. Try the same without authorization - should return 401/403

## Additional Notes

- Closes #5
