### PR TITLE
Security cors headers

### DIFF
--- a/src/main/java/com/vire/virebackend/ViReBackendApplication.java
+++ b/src/main/java/com/vire/virebackend/ViReBackendApplication.java
@@ -1,13 +1,14 @@
 package com.vire.virebackend;
 
+import com.vire.virebackend.config.CorsProperties;
 import com.vire.virebackend.config.JwtProperties;
 import com.vire.virebackend.problem.ProblemProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@ConfigurationPropertiesScan(basePackageClasses = {JwtProperties.class, ProblemProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, ProblemProperties.class, CorsProperties.class})
 public class ViReBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/vire/virebackend/config/CorsProperties.java
+++ b/src/main/java/com/vire/virebackend/config/CorsProperties.java
@@ -1,0 +1,14 @@
+package com.vire.virebackend.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+    private List<String> allowedOrigins;
+}

--- a/src/main/java/com/vire/virebackend/security/RequestSizeLimitFilter.java
+++ b/src/main/java/com/vire/virebackend/security/RequestSizeLimitFilter.java
@@ -1,0 +1,32 @@
+package com.vire.virebackend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NonNull;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class RequestSizeLimitFilter extends OncePerRequestFilter {
+    private final Long maxBytes;
+
+    public RequestSizeLimitFilter(Long maxBytes) {
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        var contentLength = request.getContentLengthLong();
+        if (contentLength > 0 && contentLength > maxBytes) {
+            response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, "Request body too large");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -49,6 +50,9 @@ public class SecurityConfig {
                                 "/actuator/**"
                         ).permitAll()
                         .anyRequest().authenticated()
+                )
+                .headers(
+                        headers -> headers.contentTypeOptions(Customizer.withDefaults()) // X-Content-Type-Options: nosniff
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationEntryPoint authenticationEntryPoint;
     private final AccessDeniedHandler accessDeniedHandler;
-    private final CorsProperties allowedOrigins;
+    private final CorsProperties corsProperties;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -68,6 +68,7 @@ public class SecurityConfig {
                                 .frameOptions(HeadersConfigurer.FrameOptionsConfig::deny) // X-Frame-Options: DENY
                                 .referrerPolicy(rp -> rp.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER))
                 )
+                .addFilterBefore(requestSizeLimitFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
@@ -81,7 +82,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         var config = new CorsConfiguration();
 
-        config.setAllowedOrigins(allowedOrigins.getAllowedOrigins());
+        config.setAllowedOrigins(corsProperties.getAllowedOrigins());
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 
@@ -106,5 +107,10 @@ public class SecurityConfig {
         var source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    @Bean
+    public RequestSizeLimitFilter requestSizeLimitFilter() {
+        return new RequestSizeLimitFilter(1_000_000L); // 1 MB
     }
 }

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,6 +18,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -61,7 +63,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .headers(
-                        headers -> headers.contentTypeOptions(Customizer.withDefaults()) // X-Content-Type-Options: nosniff
+                        headers -> headers
+                                .contentTypeOptions(Customizer.withDefaults()) // X-Content-Type-Options: nosniff
+                                .frameOptions(HeadersConfigurer.FrameOptionsConfig::deny) // X-Frame-Options: DENY
+                                .referrerPolicy(rp -> rp.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER))
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,7 @@ spring:
 
   jpa:
     show-sql: true
+
+cors:
+  allowed-origins:
+    - "http://localhost:5173"


### PR DESCRIPTION
## What’s Changed

- Enabled CORS with configurable allowed origins (via CorsProperties)
- Added basic security headers:
  - X-Content-Type-Options: nosniff
  - X-Frame-Options: DENY
  - Referrer-Policy: no-referrer
- Introduced RequestSizeLimitFilter to reject oversized request bodies (>1 MB)
- Integrated filters into Spring Security configuration

## Why

- Allow local frontend development (localhost:5173) to access backend APIs through browsers
- Strengthen baseline HTTP security by adding standard headers
- Prevent abuse with large request payloads that could affect server performance

## How to Test

1. Run the backend locally with dev profile
2. From a browser frontend (http://localhost:5173), send an authenticated request - it should succeed without CORS errors
3. Inspect any response headers (e.g. curl -I http://localhost:8080/swagger-ui/index.html) - should include X-Content-Type-Options, X-Frame-Options, Referrer-Policy
4. Send a request with a body larger than 1 MB (e.g. via Postman) - should return 413 Request Entity Too Large

## Additional Notes

- Closes #6
- Request size limit currently hardcoded to 1 MB
