### PR TITLE
Session entity and api

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/SessionController.java
+++ b/src/main/java/com/vire/virebackend/controller/SessionController.java
@@ -1,0 +1,49 @@
+package com.vire.virebackend.controller;
+
+import com.vire.virebackend.dto.session.CreateSessionRequest;
+import com.vire.virebackend.dto.session.SessionDto;
+import com.vire.virebackend.service.SessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/session")
+@RequiredArgsConstructor
+@Tag(name = "Sessions")
+public class SessionController {
+
+    private final SessionService sessionService;
+
+    @Operation(summary = "Create session for current user")
+    @PostMapping
+    public ResponseEntity<SessionDto> create(
+            Authentication auth,
+            @RequestBody(required = false) @Valid CreateSessionRequest request,
+            HttpServletRequest http
+    ) {
+        var sessionDto = sessionService.createSession(auth, request, http);
+        return ResponseEntity.ok(sessionDto);
+    }
+
+    @Operation(summary = "List current user's sessions")
+    @GetMapping
+    public ResponseEntity<List<SessionDto>> list(Authentication auth) {
+        return ResponseEntity.ok(sessionService.listMySessions(auth));
+    }
+
+    @Operation(summary = "End own session by id")
+    @DeleteMapping("{id}")
+    public ResponseEntity<Void> delete(Authentication auth, @PathVariable UUID id) {
+        var ended = sessionService.endMySession(auth, id);
+        return ended ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/vire/virebackend/dto/session/CreateSessionRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/session/CreateSessionRequest.java
@@ -1,0 +1,11 @@
+package com.vire.virebackend.dto.session;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Create session request")
+public record CreateSessionRequest(
+        @JsonProperty("device_name")
+        String deviceName
+) {
+}

--- a/src/main/java/com/vire/virebackend/dto/session/CreateSessionRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/session/CreateSessionRequest.java
@@ -2,10 +2,12 @@ package com.vire.virebackend.dto.session;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "Create session request")
 public record CreateSessionRequest(
         @JsonProperty("device_name")
+        @Size(max = 100)
         String deviceName
 ) {
 }

--- a/src/main/java/com/vire/virebackend/dto/session/SessionDto.java
+++ b/src/main/java/com/vire/virebackend/dto/session/SessionDto.java
@@ -1,0 +1,29 @@
+package com.vire.virebackend.dto.session;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Session representation")
+public record SessionDto(
+        @JsonProperty("id")
+        UUID id,
+
+        @JsonProperty("device_name")
+        String deviceName,
+
+        @JsonProperty("ip")
+        String ip,
+
+        @JsonProperty("created_at")
+        LocalDateTime createdAt,
+
+        @JsonProperty("expires_at")
+        LocalDateTime expiresAt,
+
+        @JsonProperty("is_active")
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/vire/virebackend/entity/Session.java
+++ b/src/main/java/com/vire/virebackend/entity/Session.java
@@ -3,6 +3,7 @@ package com.vire.virebackend.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "sessions")
 public class Session {
     @Id

--- a/src/main/java/com/vire/virebackend/entity/Session.java
+++ b/src/main/java/com/vire/virebackend/entity/Session.java
@@ -1,0 +1,42 @@
+package com.vire.virebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "sessions")
+public class Session {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "device_name", length = 100)
+    private String deviceName;
+
+    @Column(name = "ip", length = 45)
+    private String ip;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+}

--- a/src/main/java/com/vire/virebackend/mapper/SessionMapper.java
+++ b/src/main/java/com/vire/virebackend/mapper/SessionMapper.java
@@ -1,0 +1,17 @@
+package com.vire.virebackend.mapper;
+
+import com.vire.virebackend.dto.session.SessionDto;
+import com.vire.virebackend.entity.Session;
+
+public class SessionMapper {
+    public static SessionDto toDto(Session session) {
+        return new SessionDto(
+                session.getId(),
+                session.getDeviceName(),
+                session.getIp(),
+                session.getCreatedAt(),
+                session.getExpiresAt(),
+                session.getIsActive()
+        );
+    }
+}

--- a/src/main/java/com/vire/virebackend/repository/SessionRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/SessionRepository.java
@@ -4,8 +4,14 @@ import com.vire.virebackend.entity.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface SessionRepository extends JpaRepository<Session, UUID> {
+
+    List<Session> findAllByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    Optional<Session> findByIdAndUserId(UUID id, UUID userId);
 }

--- a/src/main/java/com/vire/virebackend/repository/SessionRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/SessionRepository.java
@@ -1,0 +1,11 @@
+package com.vire.virebackend.repository;
+
+import com.vire.virebackend.entity.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface SessionRepository extends JpaRepository<Session, UUID> {
+}

--- a/src/main/java/com/vire/virebackend/service/SessionService.java
+++ b/src/main/java/com/vire/virebackend/service/SessionService.java
@@ -1,0 +1,76 @@
+package com.vire.virebackend.service;
+
+import com.vire.virebackend.dto.session.CreateSessionRequest;
+import com.vire.virebackend.dto.session.SessionDto;
+import com.vire.virebackend.entity.Session;
+import com.vire.virebackend.mapper.SessionMapper;
+import com.vire.virebackend.repository.SessionRepository;
+import com.vire.virebackend.repository.UserRepository;
+import com.vire.virebackend.security.CustomUserDetails;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public SessionDto createSession(Authentication auth, CreateSessionRequest request, HttpServletRequest http) {
+        var userDetails = (CustomUserDetails) auth.getPrincipal();
+        var user = userRepository.findById(userDetails.getUser().getId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        var ip = extractClientIp(http);
+        var deviceName = (request != null && request.deviceName() != null && !request.deviceName().isBlank())
+                ? request.deviceName().trim()
+                : "Unknown device";
+
+        var session = Session.builder()
+                .user(user)
+                .deviceName(deviceName)
+                .ip(ip)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .isActive(true)
+                .build();
+
+        session = sessionRepository.save(session);
+        return SessionMapper.toDto(session);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SessionDto> listMySessions(Authentication auth) {
+        var userDetails = (CustomUserDetails) auth.getPrincipal();
+        return sessionRepository.findAllByUserIdOrderByCreatedAtDesc(userDetails.getUser().getId())
+                .stream().map(SessionMapper::toDto).toList();
+    }
+
+    @Transactional
+    public Boolean endMySession(Authentication auth, UUID sessionId) {
+        var userDetails = (CustomUserDetails) auth.getPrincipal();
+        var session = sessionRepository.findByIdAndUserId(sessionId, userDetails.getUser().getId())
+                .orElseThrow(() -> new EntityNotFoundException("Session not found"));
+
+        if (!session.getIsActive())
+            return false;
+
+        session.setIsActive(false);
+
+        return true;
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        // if using reverse proxy, then take into consideration forwarded
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/resources/db/changelog/03-sessions-table.yaml
+++ b/src/main/resources/db/changelog/03-sessions-table.yaml
@@ -1,0 +1,66 @@
+databaseChangeLog:
+  - changeSet:
+      id: 03-create-sessions-table
+      author: vladead
+      changes:
+        - createTable:
+            tableName: sessions
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: device_name
+                  type: varchar(100)
+              - column:
+                  name: ip
+                  type: varchar(45)
+              - column:
+                  name: created_at
+                  type: timestamp
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp
+              - column:
+                  name: is_active
+                  type: boolean
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+
+        - addForeignKeyConstraint:
+            baseTableName: sessions
+            baseColumnNames: user_id
+            constraintName: fk_sessions_user
+            referencedTableName: users
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+        - createIndex:
+            indexName: idx_sessions_user_created
+            tableName: sessions
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: created_at
+
+        - createIndex:
+            indexName: idx_sessions_user_active
+            tableName: sessions
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: is_active

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -8,4 +8,5 @@
 
     <include file="01-init-users.xml" relativeToChangelogFile="true"/>
     <include file="02-add-username.xml" relativeToChangelogFile="true"/>
+    <include file="03-sessions-table.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
## What’s Changed

- Added sessions table
- Implemented Session entity, repository, service, controller
- Endpoints: POST /api/sessions, GET /api/sessions, DELETE /api/sessions/{id}

## Why

- Mock session management required by #7

## How to Test

- Start app
- Authenticate, then:
  - POST /api/sessions to create a session
  - GET /api/sessions to list sessions
  - DELETE /api/sessions/{id} to end your session

Expected: Sessions only visible/manipulable by the owner

## Additional Notes

- Closes #7
