### PR TITLE
Actuator health info metrics

### DIFF
--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.vire.virebackend.security;
 
 import com.vire.virebackend.config.CorsProperties;
+import com.vire.virebackend.security.filter.JwtAuthenticationFilter;
+import com.vire.virebackend.security.filter.RequestSizeLimitFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.vire.virebackend.security;
 
 import com.vire.virebackend.config.CorsProperties;
 import com.vire.virebackend.security.filter.JwtAuthenticationFilter;
+import com.vire.virebackend.security.filter.MdcLoggingFilter;
 import com.vire.virebackend.security.filter.RequestSizeLimitFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -37,6 +38,7 @@ public class SecurityConfig {
     private final AuthenticationEntryPoint authenticationEntryPoint;
     private final AccessDeniedHandler accessDeniedHandler;
     private final CorsProperties corsProperties;
+    private final MdcLoggingFilter mdcLoggingFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -70,6 +72,7 @@ public class SecurityConfig {
                                 .frameOptions(HeadersConfigurer.FrameOptionsConfig::deny) // X-Frame-Options: DENY
                                 .referrerPolicy(rp -> rp.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER))
                 )
+                .addFilterBefore(mdcLoggingFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(requestSizeLimitFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/vire/virebackend/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vire/virebackend/security/filter/JwtAuthenticationFilter.java
@@ -1,13 +1,15 @@
-package com.vire.virebackend.security;
+package com.vire.virebackend.security.filter;
 
 import com.vire.virebackend.repository.UserRepository;
+import com.vire.virebackend.security.CustomUserDetails;
+import com.vire.virebackend.security.JwtService;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/vire/virebackend/security/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/vire/virebackend/security/filter/MdcLoggingFilter.java
@@ -1,0 +1,48 @@
+package com.vire.virebackend.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    public static final String TRACE_ID = "traceId";
+    public static final String TRACE_HEADER = "X-Trace-Id";
+    public static final String REQUEST_ID = "requestId";
+    public static final String REQUEST_HEADER = "X-Request-Id";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        var traceId = getOrGenerate(request, TRACE_HEADER);
+        var requestId = getOrGenerate(request, REQUEST_HEADER);
+
+        MDC.put(TRACE_ID, traceId);
+        MDC.put(REQUEST_ID, requestId);
+
+        response.setHeader(TRACE_HEADER, traceId);
+        response.setHeader(REQUEST_HEADER, requestId);
+
+        try (var ignored = MDC.putCloseable(TRACE_ID, traceId);
+             var ignored1 = MDC.putCloseable(REQUEST_ID, requestId)) {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    private String getOrGenerate(HttpServletRequest request, String header) {
+        var value = request.getHeader(header);
+        return (value != null && !value.isBlank()) ? value : UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/vire/virebackend/security/filter/RequestSizeLimitFilter.java
+++ b/src/main/java/com/vire/virebackend/security/filter/RequestSizeLimitFilter.java
@@ -1,10 +1,10 @@
-package com.vire.virebackend.security;
+package com.vire.virebackend.security.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.jspecify.annotations.NonNull;
+import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,9 @@ management:
     health:
       probes:
         enabled: true
+  info:
+    env:
+      enabled: true
 
 problem:
   base-uri: https://vire.dev/problems/
@@ -54,3 +57,13 @@ springdoc:
   swagger-ui:
     display-request-duration: true
     display-operation-id: true
+
+info:
+  app:
+    name: ${spring.application.name}
+    version: ${APP_VERSION:0.0.1-SNAPSHOT}
+    description: ViRe backend service
+
+logging:
+  pattern:
+    level: "%5p [traceId=%X{traceId:-},requestId=%X{requestId:-}]"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,11 +37,11 @@ jwt:
 
 management:
   server:
-    port: 8081
+    port: ${ACTUATOR_PORT:8081}
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health, info, metrics
   endpoint:
     health:
       probes:

--- a/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
+++ b/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
@@ -7,7 +7,7 @@ import com.vire.virebackend.problem.ProblemFactory;
 import com.vire.virebackend.problem.ProblemProperties;
 import com.vire.virebackend.problem.ProblemTypeResolver;
 import com.vire.virebackend.repository.UserRepository;
-import com.vire.virebackend.security.JwtAuthenticationFilter;
+import com.vire.virebackend.security.filter.JwtAuthenticationFilter;
 import com.vire.virebackend.security.JwtService;
 import com.vire.virebackend.security.SecurityConfig;
 import com.vire.virebackend.security.handler.SecurityProblemHandlers;


### PR DESCRIPTION
## What’s Changed

- Add actuator endpoint (/metrics)
- Add info.app.* properties to application.yml
- Add MDC logging filter to inject traceId/requestId and return them in response headers
- Update log pattern to include traceId/requestId
- Parameterize actuator port (default is set to 8081, not exposed in container) 

## Why

- Improve observability for local development and operations: health checks, service metadata, basic metrics, and log correlation per request

## How to Test

- Start app
  - curl http://localhost:8081/actuator/info
  - curl http://localhost:8081/actuator/health
  - curl http://localhost:8081/actuator/info
- Trigger any app endpoint (e.g. GET /api/user/me) and check container logs.
  - Optional: send custom headers to verify propagation:
    - X-Trace-Id: test-trace
    - X-Request-Id: test-request
- Expected result:
  - Actuator endpoints return data as expected (health OK, info shows info.app.*, metrics list appears).
  - Log lines contain [traceId=...,requestId=...]. Response headers include X-Trace-Id and X-Request-Id.

## Additional Notes

- Closes #9 
