### PR TITLE
Negative authentication cases

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -22,6 +24,7 @@ import java.util.*;
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class GlobalExceptionHandler {
 
     private final ProblemFactory problemFactory;
@@ -84,6 +87,7 @@ public class GlobalExceptionHandler {
     // 500 others
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleAny(Exception exception) {
+        // todo: extract to different RestControllerAdvice with lowest precedence
         var incidentId = UUID.randomUUID();
         log.error("Unhandled exception, incidentId={}", incidentId, exception);
 


### PR DESCRIPTION
## What’s Changed

- Add 401 mapping for AuthenticationException in GlobalExceptionHandler (ProblemDetail)
- Add 409 mapping for DataIntegrityViolationException with WWW-Authenticate header
- Add WebMvc tests for negative auth flows:
  - Duplicate email/username -> 409
  - GET /api/user/me without token -> 401
  - GET /api/user/me with valid (mocked) token -> 200

## Why

- Ensure API returns correct status codes and RFC 7807 ProblemDetail for negative auth scenarios

## How to Test

1. Run tests

## Additional Notes

- Closes #10
