### PR TITLE
Roles and permissions

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.vire.virebackend.controller;
+
+import com.vire.virebackend.dto.user.UserDto;
+import com.vire.virebackend.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/admin")
+@RequiredArgsConstructor
+@Tag(name = "Admin")
+@SecurityRequirement(name = "bearerAuth")
+public class AdminController {
+
+    private final UserService userService;
+
+    @Operation(summary = "List all users (admin)")
+    @GetMapping("users")
+    public ResponseEntity<List<UserDto>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+}

--- a/src/main/java/com/vire/virebackend/dto/user/UserDto.java
+++ b/src/main/java/com/vire/virebackend/dto/user/UserDto.java
@@ -1,5 +1,7 @@
 package com.vire.virebackend.dto.user;
 
+import com.vire.virebackend.entity.Role;
+import com.vire.virebackend.entity.User;
 import com.vire.virebackend.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -22,6 +24,16 @@ public record UserDto(
                 userDetails.getUsername(),
                 userDetails.getAuthorities().stream()
                         .map(GrantedAuthority::getAuthority)
+                        .toList()
+        );
+    }
+
+    public static UserDto from(User user) {
+        return new UserDto(
+                user.getId(),
+                user.getEmail(),
+                user.getRoles().stream()
+                        .map(Role::getName)
                         .toList()
         );
     }

--- a/src/main/java/com/vire/virebackend/entity/Role.java
+++ b/src/main/java/com/vire/virebackend/entity/Role.java
@@ -1,0 +1,33 @@
+package com.vire.virebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "name", length = 50)
+    private String name;
+
+    /**
+     * Jpa hook to make sure all roles are in upper case
+     */
+    @PrePersist
+    @PreUpdate
+    private void normalize() {
+        if (name != null) name = name.trim().toUpperCase();
+    }
+}

--- a/src/main/java/com/vire/virebackend/entity/User.java
+++ b/src/main/java/com/vire/virebackend/entity/User.java
@@ -42,7 +42,7 @@ public class User extends BaseEntity {
     private Long version;
 
     @Builder.Default
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
         name = "user_roles",
         joinColumns = @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_roles_user")),

--- a/src/main/java/com/vire/virebackend/entity/User.java
+++ b/src/main/java/com/vire/virebackend/entity/User.java
@@ -1,7 +1,15 @@
 package com.vire.virebackend.entity;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.*;
@@ -32,4 +40,13 @@ public class User extends BaseEntity {
     @Setter(AccessLevel.NONE)
     @Column(name = "version", nullable = false)
     private Long version;
+
+    @Builder.Default
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "user_roles",
+        joinColumns = @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_roles_user")),
+        inverseJoinColumns =  @JoinColumn(name = "role_id", foreignKey = @ForeignKey(name = "fk_user_roles_role"))
+    )
+    private Set<Role> roles = new HashSet<>();
 }

--- a/src/main/java/com/vire/virebackend/repository/RoleRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.vire.virebackend.repository;
+
+import com.vire.virebackend.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+}

--- a/src/main/java/com/vire/virebackend/repository/RoleRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/RoleRepository.java
@@ -4,8 +4,11 @@ import com.vire.virebackend.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface RoleRepository extends JpaRepository<Role, UUID> {
+
+    Optional<Role> findByName(String name);
 }

--- a/src/main/java/com/vire/virebackend/security/CustomUserDetails.java
+++ b/src/main/java/com/vire/virebackend/security/CustomUserDetails.java
@@ -2,8 +2,7 @@ package com.vire.virebackend.security;
 
 import com.vire.virebackend.entity.User;
 import lombok.Getter;
-
-import java.util.List;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @Getter
 public class CustomUserDetails extends org.springframework.security.core.userdetails.User {
@@ -18,7 +17,9 @@ public class CustomUserDetails extends org.springframework.security.core.userdet
                 true,
                 true,
                 true,
-                List.of() // there is no roles for now
+                user.getRoles().stream()
+                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getName()))
+                        .toList()
         );
         this.user = user;
     }

--- a/src/main/java/com/vire/virebackend/security/JwtService.java
+++ b/src/main/java/com/vire/virebackend/security/JwtService.java
@@ -1,6 +1,7 @@
 package com.vire.virebackend.security;
 
 import com.vire.virebackend.config.JwtProperties;
+import com.vire.virebackend.entity.Role;
 import com.vire.virebackend.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -26,6 +27,7 @@ public class JwtService {
     public String generateToken(User user) {
         return Jwts.builder()
                 .subject(user.getId().toString())
+                .claim("roles", user.getRoles().stream().map(Role::getName).toList())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().toMillis()))
                 .signWith(getSignKey(), Jwts.SIG.HS512)

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.vire.virebackend.security.filter.RequestSizeLimitFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -64,6 +65,8 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/actuator/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/user/me").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/admin/users").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .headers(

--- a/src/main/java/com/vire/virebackend/service/AuthService.java
+++ b/src/main/java/com/vire/virebackend/service/AuthService.java
@@ -5,6 +5,7 @@ import com.vire.virebackend.dto.auth.LoginResponse;
 import com.vire.virebackend.dto.auth.RegisterRequest;
 import com.vire.virebackend.dto.auth.RegisterResponse;
 import com.vire.virebackend.entity.User;
+import com.vire.virebackend.repository.RoleRepository;
 import com.vire.virebackend.repository.UserRepository;
 import com.vire.virebackend.security.CustomUserDetails;
 import com.vire.virebackend.security.JwtService;
@@ -22,6 +23,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
+    private final RoleRepository roleRepository;
 
     public RegisterResponse register(RegisterRequest request) {
         var user = User.builder()
@@ -29,6 +31,10 @@ public class AuthService {
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .build();
+
+        var userRole = roleRepository.findByName("USER")
+                        .orElseThrow(() -> new IllegalStateException("Default role USER not found"));
+        user.getRoles().add(userRole);
 
         userRepository.save(user);
 

--- a/src/main/java/com/vire/virebackend/service/UserService.java
+++ b/src/main/java/com/vire/virebackend/service/UserService.java
@@ -1,12 +1,21 @@
 package com.vire.virebackend.service;
 
+import com.vire.virebackend.dto.user.UserDto;
 import com.vire.virebackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+
+    public List<UserDto> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(UserDto::from)
+                .toList();
+    }
 }

--- a/src/main/resources/db/changelog/06-create-roles-and-user-roles-tables.yaml
+++ b/src/main/resources/db/changelog/06-create-roles-and-user-roles-tables.yaml
@@ -1,0 +1,79 @@
+databaseChangeLog:
+  - changeSet:
+      id: 06-create-roles-table
+      author: vladead
+      changes:
+        - createTable:
+            tableName: roles
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(50)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: roles
+            columnNames: name
+            constraintName: uq_roles_name
+      rollback:
+        - dropTable:
+            tableName: roles
+            cascadeConstraints: true
+
+  - changeSet:
+      id: 06-create-user-roles-table
+      author: vladead
+      changes:
+        - createTable:
+            tableName: user_roles
+            columns:
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: user_roles
+            columnNames: user_id, role_id
+            constraintName: pk_user_roles
+        - addForeignKeyConstraint:
+            baseTableName: user_roles
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            onDelete: CASCADE
+            constraintName: fk_user_roles_user
+        - addForeignKeyConstraint:
+            baseTableName: user_roles
+            baseColumnNames: role_id
+            referencedTableName: roles
+            referencedColumnNames: id
+            onDelete: RESTRICT
+            constraintName: fk_user_roles_role
+        - createIndex:
+            tableName: user_roles
+            indexName: idx_user_roles_user
+            columns:
+              - column:
+                  name: user_id
+        - createIndex:
+            tableName: user_roles
+            indexName: idx_user_roles_role
+            columns:
+              - column:
+                  name: role_id
+      rollback:
+        - dropTable:
+            tableName: user_roles
+            cascadeConstraints: true

--- a/src/main/resources/db/changelog/07-seed-roles.yaml
+++ b/src/main/resources/db/changelog/07-seed-roles.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 07-seed-roles
+      author: vladead
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO roles (id, name)
+              VALUES ('11111111-1111-1111-1111-111111111111', 'USER')
+              ON CONFLICT (name) DO NOTHING;
+        - sql:
+            sql: |
+              INSERT INTO roles (id, name)
+              VALUES ('22222222-2222-2222-2222-222222222222', 'ADMIN')
+              ON CONFLICT (name) DO NOTHING;
+      rollback:
+        - delete:
+            tableName: roles
+            where: "id IN ('11111111-1111-1111-1111-111111111111','22222222-2222-2222-2222-222222222222')"

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -17,3 +17,6 @@ databaseChangeLog:
   - include:
       file: 06-create-roles-and-user-roles-tables.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 07-seed-roles.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -14,3 +14,6 @@ databaseChangeLog:
   - include:
       file: 05-add-version-users.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 06-create-roles-and-user-roles-tables.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## What’s Changed

- Add roles and user_roles tables and entities
- Seed roles table with default roles: USER, ADMIN
- Add jwt claims with roles
- Set default role USER at registration
- Add admin controller with api/admin/users endpoint
- Set access rules for api/user/me and api/admin/users:
  - api/user/me (USER, ADMIN)
  -  api/admin/users (ADMIN)
- Map ROLE_ prefix in CustomUserDetails

## Why

- Add basic role logic to project

## How to Test

1. Start app
2. Register user
3. Try GET /api/user/me
4. Try GET /api/admin/users

Expected results:
- GET /api/user/me - OK response with id, email and roles
- GET /api/admin/users - Forbidden

To get list of users in GET /api/admin/users, try to manually add ADMIN role for preferred user in db

## Additional Notes

- Closes #25 
