### PR TITLE
Tariff plans

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -1,15 +1,18 @@
 package com.vire.virebackend.controller;
 
+import com.vire.virebackend.dto.plan.CreatePlanRequest;
+import com.vire.virebackend.dto.plan.PlanDto;
 import com.vire.virebackend.dto.user.UserDto;
+import com.vire.virebackend.service.PlanService;
 import com.vire.virebackend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.List;
 
@@ -21,10 +24,25 @@ import java.util.List;
 public class AdminController {
 
     private final UserService userService;
+    private final PlanService planService;
 
     @Operation(summary = "List all users (admin)")
     @GetMapping("users")
     public ResponseEntity<List<UserDto>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    @Operation(summary = "Create a new plan")
+    @PostMapping("plans")
+    public ResponseEntity<PlanDto> create(@Valid @RequestBody CreatePlanRequest request) {
+        var created = planService.createPlan(request);
+
+        var location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/api/plans/{id}")
+                .buildAndExpand(created.id())
+                .toUri();
+
+        return ResponseEntity.created(location).body(created);
     }
 }

--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.vire.virebackend.controller;
 
 import com.vire.virebackend.dto.plan.CreatePlanRequest;
 import com.vire.virebackend.dto.plan.PlanDto;
+import com.vire.virebackend.dto.plan.UpdatePlanRequest;
 import com.vire.virebackend.dto.user.UserDto;
 import com.vire.virebackend.service.PlanService;
 import com.vire.virebackend.service.UserService;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("api/admin")
@@ -44,5 +46,14 @@ public class AdminController {
                 .toUri();
 
         return ResponseEntity.created(location).body(created);
+    }
+
+    @Operation(summary = "Update an existing plan")
+    @PutMapping("plans/{id}")
+    public ResponseEntity<PlanDto> update(
+            @Valid @RequestBody UpdatePlanRequest request,
+            @PathVariable UUID id
+    ) {
+        return ResponseEntity.ok(planService.updatePlan(request, id));
     }
 }

--- a/src/main/java/com/vire/virebackend/controller/PlanController.java
+++ b/src/main/java/com/vire/virebackend/controller/PlanController.java
@@ -3,15 +3,16 @@ package com.vire.virebackend.controller;
 import com.vire.virebackend.dto.plan.PlanDto;
 import com.vire.virebackend.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("api/plans")
@@ -25,5 +26,11 @@ public class PlanController {
     @GetMapping
     public ResponseEntity<List<PlanDto>> getAllPlans() {
         return ResponseEntity.ok(planService.getAllPlans());
+    }
+
+    @Operation(summary = "Get plan by id")
+    @GetMapping("{id}")
+    public ResponseEntity<PlanDto> getPlan(@PathVariable UUID id) {
+        return ResponseEntity.ok(planService.getPlan(id));
     }
 }

--- a/src/main/java/com/vire/virebackend/controller/PlanController.java
+++ b/src/main/java/com/vire/virebackend/controller/PlanController.java
@@ -1,0 +1,29 @@
+package com.vire.virebackend.controller;
+
+import com.vire.virebackend.dto.plan.PlanDto;
+import com.vire.virebackend.service.PlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/plans")
+@RequiredArgsConstructor
+@Tag(name = "Plans")
+public class PlanController {
+
+    private final PlanService planService;
+
+    @Operation(summary = "List all plans")
+    @GetMapping
+    public ResponseEntity<List<PlanDto>> getAllPlans() {
+        return ResponseEntity.ok(planService.getAllPlans());
+    }
+}

--- a/src/main/java/com/vire/virebackend/dto/plan/CreatePlanRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/plan/CreatePlanRequest.java
@@ -1,0 +1,26 @@
+package com.vire.virebackend.dto.plan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+
+public record CreatePlanRequest(
+        @JsonProperty("name")
+        @NotBlank
+        @Size(max = 64)
+        @Pattern(regexp = "^[A-Za-z0-9\\s_-]+$")
+        String name,
+
+        @JsonProperty("price")
+        @NotNull
+        @DecimalMin(value = "0.00")
+        @Digits(integer = 12, fraction = 2)
+        BigDecimal price,
+
+        @JsonProperty("duration_days")
+        @NotNull
+        @Positive
+        Integer durationDays
+) {
+}

--- a/src/main/java/com/vire/virebackend/dto/plan/PlanDto.java
+++ b/src/main/java/com/vire/virebackend/dto/plan/PlanDto.java
@@ -1,0 +1,23 @@
+package com.vire.virebackend.dto.plan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Schema(description = "Plan representation")
+public record PlanDto(
+        @JsonProperty("id")
+        UUID id,
+
+        @JsonProperty("name")
+        String name,
+
+        @JsonProperty("price")
+        BigDecimal price,
+
+        @JsonProperty("duration_days")
+        Integer durationDays
+) {
+}

--- a/src/main/java/com/vire/virebackend/dto/plan/UpdatePlanRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/plan/UpdatePlanRequest.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
 
-@Schema(description = "Create new plan request")
-public record CreatePlanRequest(
+@Schema(description = "Update an existing plan request")
+public record UpdatePlanRequest(
         @JsonProperty("name")
         @NotBlank
         @Size(max = 64)

--- a/src/main/java/com/vire/virebackend/entity/Plan.java
+++ b/src/main/java/com/vire/virebackend/entity/Plan.java
@@ -1,0 +1,31 @@
+package com.vire.virebackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "plans")
+public class Plan extends BaseEntity {
+
+    @Column(name = "name", unique = true, nullable = false, length = 64)
+    private String name;
+
+    @DecimalMin(value = "0.00")
+    @Column(name = "price", nullable = false, precision = 12, scale = 2)
+    private BigDecimal price;
+
+    @Positive
+    @Column(name = "duration_days", nullable = false)
+    private Integer durationDays;
+}

--- a/src/main/java/com/vire/virebackend/mapper/PlanMapper.java
+++ b/src/main/java/com/vire/virebackend/mapper/PlanMapper.java
@@ -1,0 +1,15 @@
+package com.vire.virebackend.mapper;
+
+import com.vire.virebackend.dto.plan.PlanDto;
+import com.vire.virebackend.entity.Plan;
+
+public class PlanMapper {
+    public static PlanDto toDto(Plan plan) {
+        return new PlanDto(
+                plan.getId(),
+                plan.getName(),
+                plan.getPrice(),
+                plan.getDurationDays()
+        );
+    }
+}

--- a/src/main/java/com/vire/virebackend/repository/PlanRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/PlanRepository.java
@@ -1,0 +1,11 @@
+package com.vire.virebackend.repository;
+
+import com.vire.virebackend.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, UUID> {
+}

--- a/src/main/java/com/vire/virebackend/repository/PlanRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/PlanRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface PlanRepository extends JpaRepository<Plan, UUID> {
 
     Boolean existsByNameIgnoreCase(String name);
+
+    Boolean existsByNameIgnoreCaseAndIdNot(String name, UUID id);
 }

--- a/src/main/java/com/vire/virebackend/repository/PlanRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/PlanRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, UUID> {
+
+    Boolean existsByNameIgnoreCase(String name);
 }

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
-                                "/actuator/**"
+                                "/actuator/**",
+                                "/api/plans"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/user/me").hasAnyRole("USER", "ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/admin/users").hasRole("ADMIN")

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                                 "/actuator/**",
                                 "/api/plans"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "api/plans/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/user/me").hasAnyRole("USER", "ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/admin/users").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "api/plans/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/user/me").hasAnyRole("USER", "ADMIN")
-                        .requestMatchers(HttpMethod.GET, "/api/admin/users").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .headers(

--- a/src/main/java/com/vire/virebackend/service/PlanService.java
+++ b/src/main/java/com/vire/virebackend/service/PlanService.java
@@ -2,6 +2,7 @@ package com.vire.virebackend.service;
 
 import com.vire.virebackend.dto.plan.CreatePlanRequest;
 import com.vire.virebackend.dto.plan.PlanDto;
+import com.vire.virebackend.dto.plan.UpdatePlanRequest;
 import com.vire.virebackend.entity.Plan;
 import com.vire.virebackend.mapper.PlanMapper;
 import com.vire.virebackend.repository.PlanRepository;
@@ -41,10 +42,26 @@ public class PlanService {
         }
 
         var plan = Plan.builder()
-                .name(request.name())
+                .name(request.name().trim())
                 .price(request.price())
                 .durationDays(request.durationDays())
                 .build();
+
+        return PlanMapper.toDto(planRepository.save(plan));
+    }
+
+    @Transactional
+    public PlanDto updatePlan(UpdatePlanRequest request, UUID id) {
+        var plan = planRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Plan not found"));
+
+        if (planRepository.existsByNameIgnoreCaseAndIdNot(request.name(), id)) {
+            throw new DataIntegrityViolationException("Plan name already exists");
+        }
+
+        plan.setName(request.name().trim());
+        plan.setPrice(request.price());
+        plan.setDurationDays(request.durationDays());
 
         return PlanMapper.toDto(planRepository.save(plan));
     }

--- a/src/main/java/com/vire/virebackend/service/PlanService.java
+++ b/src/main/java/com/vire/virebackend/service/PlanService.java
@@ -1,10 +1,13 @@
 package com.vire.virebackend.service;
 
+import com.vire.virebackend.dto.plan.CreatePlanRequest;
 import com.vire.virebackend.dto.plan.PlanDto;
+import com.vire.virebackend.entity.Plan;
 import com.vire.virebackend.mapper.PlanMapper;
 import com.vire.virebackend.repository.PlanRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,5 +32,20 @@ public class PlanService {
                 .orElseThrow(() -> new EntityNotFoundException("Plan not found"));
 
         return PlanMapper.toDto(plan);
+    }
+
+    @Transactional
+    public PlanDto createPlan(CreatePlanRequest request) {
+        if (planRepository.existsByNameIgnoreCase(request.name())) {
+            throw new DataIntegrityViolationException("Plan name already exists");
+        }
+
+        var plan = Plan.builder()
+                .name(request.name())
+                .price(request.price())
+                .durationDays(request.durationDays())
+                .build();
+
+        return PlanMapper.toDto(planRepository.save(plan));
     }
 }

--- a/src/main/java/com/vire/virebackend/service/PlanService.java
+++ b/src/main/java/com/vire/virebackend/service/PlanService.java
@@ -3,11 +3,13 @@ package com.vire.virebackend.service;
 import com.vire.virebackend.dto.plan.PlanDto;
 import com.vire.virebackend.mapper.PlanMapper;
 import com.vire.virebackend.repository.PlanRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -19,5 +21,13 @@ public class PlanService {
     public List<PlanDto> getAllPlans() {
         return planRepository.findAll()
                 .stream().map(PlanMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PlanDto getPlan(UUID id) {
+        var plan = planRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Plan not found"));
+
+        return PlanMapper.toDto(plan);
     }
 }

--- a/src/main/java/com/vire/virebackend/service/PlanService.java
+++ b/src/main/java/com/vire/virebackend/service/PlanService.java
@@ -1,0 +1,23 @@
+package com.vire.virebackend.service;
+
+import com.vire.virebackend.dto.plan.PlanDto;
+import com.vire.virebackend.mapper.PlanMapper;
+import com.vire.virebackend.repository.PlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    @Transactional(readOnly = true)
+    public List<PlanDto> getAllPlans() {
+        return planRepository.findAll()
+                .stream().map(PlanMapper::toDto).toList();
+    }
+}

--- a/src/main/resources/db/changelog/08-create-plans-table.yaml
+++ b/src/main/resources/db/changelog/08-create-plans-table.yaml
@@ -1,0 +1,46 @@
+databaseChangeLog:
+  - changeSet:
+      id: 08-create-plans-table
+      author: vladead
+      changes:
+        - createTable:
+            tableName: plans
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: price
+                  type: numeric(12, 2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: duration_days
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamp
+        - addUniqueConstraint:
+            tableName: plans
+            columnNames: name
+            constraintName: uq_plans_name
+      rollback:
+        - dropTable:
+            tableName: plans
+            cascadeConstraints: true

--- a/src/main/resources/db/changelog/09-seed-plans.yaml
+++ b/src/main/resources/db/changelog/09-seed-plans.yaml
@@ -1,0 +1,75 @@
+databaseChangeLog:
+  - changeSet:
+      id: 09-seed-plans
+      author: vladead
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - insert:
+            tableName: plans
+            columns:
+              - column:
+                  name: id
+                  value: "11111111-3111-4111-5111-111111111111"
+              - column:
+                  name: name
+                  value: "Month"
+              - column:
+                  name: price
+                  valueNumeric: 9.99
+              - column:
+                  name: duration_days
+                  valueNumeric: 30
+              - column:
+                  name: created_at
+                  valueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  valueComputed: CURRENT_TIMESTAMP
+        - insert:
+            tableName: plans
+            columns:
+              - column:
+                  name: id
+                  value: "22222222-3222-4222-5222-222222222222"
+              - column:
+                  name: name
+                  value: "6 Months"
+              - column:
+                  name: price
+                  valueNumeric: 49.99
+              - column:
+                  name: duration_days
+                  valueNumeric: 180
+              - column:
+                  name: created_at
+                  valueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  valueComputed: CURRENT_TIMESTAMP
+        - insert:
+            tableName: plans
+            columns:
+              - column:
+                  name: id
+                  value: "33333333-3333-4333-5333-333333333333"
+              - column:
+                  name: name
+                  value: "Year"
+              - column:
+                  name: price
+                  valueNumeric: 89.99
+              - column:
+                  name: duration_days
+                  valueNumeric: 365
+              - column:
+                  name: created_at
+                  valueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  valueComputed: CURRENT_TIMESTAMP
+      rollback:
+        - delete:
+            tableName: plans
+            where: "id IN ('11111111-3111-4111-5111-111111111111', '22222222-3222-4222-5222-222222222222', '33333333-3333-4333-5333-333333333333')"

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -20,3 +20,6 @@ databaseChangeLog:
   - include:
       file: 07-seed-roles.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 08-create-plans-table.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -23,3 +23,6 @@ databaseChangeLog:
   - include:
       file: 08-create-plans-table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 09-seed-plans.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## What’s Changed

- Added Plan entity and Liquibase migrations (plans table + seed: Month, 6 Months, Year)
- Implemented GET /api/plans/{id} endpoint (public)
- Implemented POST /api/admin/plans endpoint (create plan, ADMIN only)
- Implemented PUT /api/admin/plans/{id} endpoint (update plan, ADMIN only)
- Secured all /api/admin/** endpoints with ROLE_ADMIN

## Why

- Needed basic CRUD endpoints to manage tariff plans (catalog for users, create/update for admins)
- No payment or proration logic, only mock functionality for MVP

## How to Test

- Start App
- Call GET /api/plans - should return seeded plans (Month, 6 Months, Year)
- Login as admin user and call:
  - POST /api/admin/plans with valid payload - should return 201 Created and new plan
  - PUT /api/admin/plans/{id} with updated payload - should return 200 OK and updated plan
- Try the same requests as non-admin user - should return 403 Forbidden

## Additional Notes

- Closes #26 
