### PR TITLE
User subscriptions

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/UserController.java
+++ b/src/main/java/com/vire/virebackend/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.vire.virebackend.controller;
 
+import com.vire.virebackend.dto.plan.UserPlanDto;
 import com.vire.virebackend.dto.user.UserDto;
 import com.vire.virebackend.security.CustomUserDetails;
+import com.vire.virebackend.service.UserPlanService;
 import com.vire.virebackend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("api/user")
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final UserPlanService userPlanService;
 
     @Operation(
             summary = "Get current user info from JWT",
@@ -37,5 +42,11 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return ResponseEntity.ok(UserDto.from(userDetails));
+    }
+
+    @Operation(summary = "Get current user plans")
+    @GetMapping("plans")
+    public ResponseEntity<List<UserPlanDto>> getCurrentUserPlans(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(userPlanService.userSubscriptions(userDetails.getUser().getId()));
     }
 }

--- a/src/main/java/com/vire/virebackend/controller/UserPlanController.java
+++ b/src/main/java/com/vire/virebackend/controller/UserPlanController.java
@@ -1,0 +1,39 @@
+package com.vire.virebackend.controller;
+
+import com.vire.virebackend.dto.plan.UserPlanDto;
+import com.vire.virebackend.security.CustomUserDetails;
+import com.vire.virebackend.service.UserPlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/plans")
+@RequiredArgsConstructor
+@Tag(name = "User plans")
+@SecurityRequirement(name = "bearerAuth")
+public class UserPlanController {
+
+    private final UserPlanService userPlanService;
+
+    @Operation(summary = "Subscribe current user to the plan")
+    @PostMapping("{id}/subscribe")
+    public ResponseEntity<UserPlanDto> subscribe(
+            @PathVariable("id") UUID planId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        var userId = userDetails.getUser().getId();
+        var response = userPlanService.subscribe(planId, userId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/vire/virebackend/dto/plan/UserPlanDto.java
+++ b/src/main/java/com/vire/virebackend/dto/plan/UserPlanDto.java
@@ -1,0 +1,26 @@
+package com.vire.virebackend.dto.plan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "User plan representation")
+public record UserPlanDto(
+        @JsonProperty("id")
+        UUID id,
+
+        @JsonProperty("user_id")
+        UUID userId,
+
+        @JsonProperty("plan_id")
+        UUID planId,
+
+        @JsonProperty("start_date")
+        LocalDateTime startDate,
+
+        @JsonProperty("end_date")
+        LocalDateTime endDate
+) {
+}

--- a/src/main/java/com/vire/virebackend/entity/UserPlan.java
+++ b/src/main/java/com/vire/virebackend/entity/UserPlan.java
@@ -1,0 +1,30 @@
+package com.vire.virebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "user_plans")
+public class UserPlan extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/vire/virebackend/mapper/UserPlanMapper.java
+++ b/src/main/java/com/vire/virebackend/mapper/UserPlanMapper.java
@@ -1,0 +1,16 @@
+package com.vire.virebackend.mapper;
+
+import com.vire.virebackend.dto.plan.UserPlanDto;
+import com.vire.virebackend.entity.UserPlan;
+
+public final class UserPlanMapper {
+    public static UserPlanDto toDto(UserPlan userPlan) {
+        return new UserPlanDto(
+                userPlan.getId(),
+                userPlan.getUser().getId(),
+                userPlan.getPlan().getId(),
+                userPlan.getStartDate(),
+                userPlan.getEndDate()
+        );
+    }
+}

--- a/src/main/java/com/vire/virebackend/repository/UserPlanRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/UserPlanRepository.java
@@ -4,8 +4,11 @@ import com.vire.virebackend.entity.UserPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface UserPlanRepository extends JpaRepository<UserPlan, UUID> {
+
+    List<UserPlan> findByUserIdOrderByStartDateDesc(UUID userId);
 }

--- a/src/main/java/com/vire/virebackend/repository/UserPlanRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/UserPlanRepository.java
@@ -1,0 +1,11 @@
+package com.vire.virebackend.repository;
+
+import com.vire.virebackend.entity.UserPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface UserPlanRepository extends JpaRepository<UserPlan, UUID> {
+}

--- a/src/main/java/com/vire/virebackend/service/UserPlanService.java
+++ b/src/main/java/com/vire/virebackend/service/UserPlanService.java
@@ -1,0 +1,39 @@
+package com.vire.virebackend.service;
+
+import com.vire.virebackend.dto.plan.UserPlanDto;
+import com.vire.virebackend.entity.UserPlan;
+import com.vire.virebackend.mapper.UserPlanMapper;
+import com.vire.virebackend.repository.PlanRepository;
+import com.vire.virebackend.repository.UserPlanRepository;
+import com.vire.virebackend.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserPlanService {
+
+    private final UserRepository userRepository;
+    private final PlanRepository planRepository;
+    private final UserPlanRepository userPlanRepository;
+
+    @Transactional
+    public UserPlanDto subscribe(UUID planId, UUID userId) {
+        var plan = planRepository.findById(planId)
+                .orElseThrow(() -> new EntityNotFoundException("Plan not found"));
+
+        var userPlan = UserPlan.builder()
+                .user(userRepository.getReferenceById(userId))
+                .plan(plan)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(plan.getDurationDays()))
+                .build();
+
+        return UserPlanMapper.toDto(userPlanRepository.save(userPlan));
+    }
+}

--- a/src/main/java/com/vire/virebackend/service/UserPlanService.java
+++ b/src/main/java/com/vire/virebackend/service/UserPlanService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -35,5 +36,11 @@ public class UserPlanService {
                 .build();
 
         return UserPlanMapper.toDto(userPlanRepository.save(userPlan));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserPlanDto> userSubscriptions(UUID userId) {
+        return userPlanRepository.findByUserIdOrderByStartDateDesc(userId)
+                .stream().map(UserPlanMapper::toDto).toList();
     }
 }

--- a/src/main/resources/db/changelog/10-create-user-plans-table.yaml
+++ b/src/main/resources/db/changelog/10-create-user-plans-table.yaml
@@ -1,0 +1,78 @@
+databaseChangeLog:
+  - changeSet:
+      id: 10-create-user-plans-table
+      author: vladead
+      changes:
+        - createTable:
+            tableName: user_plans
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: plan_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_date
+                  type: timestamp
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_date
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: user_plans
+            baseColumnNames: user_id
+            constraintName: fk_user_plans_user
+            referencedTableName: users
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: user_plans
+            baseColumnNames: plan_id
+            constraintName: fk_user_plans_plan
+            referencedTableName: plans
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_user_plans_user_start
+            tableName: user_plans
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: start_date
+        - createIndex:
+            indexName: idx_user_plans_user
+            tableName: user_plans
+            columns:
+              - column:
+                  name: user_id
+      rollback:
+        - dropTable:
+            tableName: user_plans
+            cascadeConstraints: true

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -26,3 +26,6 @@ databaseChangeLog:
   - include:
       file: 09-seed-plans.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 10-create-user-plans-table.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## What’s Changed

- Liquibase migration for user_plans table with FKs to users and plans
- UserPlan entity, repository, DTO, and mapper
- UserPlanService with methods to subscribe a user to a plan and list their subscriptions
- Implemented endpoint POST /api/plans/{id}/subscribe (authenticated user subscribes to a plan)
- Implemented endpoint GET /api/user/plans (list current user’s subscriptions)

## Why

- Provides a way for users to attach themselves to a plan without payment/renewal logic
- Forms the basis for future subscription management and billing integration

## How to Test

- Start app
- Login as a regular user and get a JWT token
- Call POST /api/plans/{id}/subscribe with an existing plan ID
  - Expected: 201 Created with subscription details (start date = now, end date = now + durationDays)
- Call GET /api/user/plans
  - Expected: list of subscriptions for the current user (including the one just created)
- Call the same endpoints without authentication
  - Expected: 401 Unauthorized

## Additional Notes

- Closes #27 
