### PR TITLE
Observability/trace incident correlation 28

### DIFF
--- a/src/main/java/com/vire/virebackend/problem/ProblemFactory.java
+++ b/src/main/java/com/vire/virebackend/problem/ProblemFactory.java
@@ -46,6 +46,20 @@ public class ProblemFactory {
         return problemDetail;
     }
 
+    public ProblemDetail internal(String incidentId) {
+        var problemDetail = of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ProblemType.INTERNAL,
+                "Internal server error",
+                "If the problem persists, contact support and mention incidentId");
+        problemDetail.setProperty(
+                "incidentId",
+                (incidentId != null && !incidentId.isBlank()) ? incidentId : UUID.randomUUID()
+        );
+
+        return problemDetail;
+    }
+
     public ProblemDetail badRequest(String detail) {
         return of(
                 HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/vire/virebackend/security/SecurityConfig.java
+++ b/src/main/java/com/vire/virebackend/security/SecurityConfig.java
@@ -110,7 +110,9 @@ public class SecurityConfig {
         config.setMaxAge(Duration.ofHours(1));
 
         config.setExposedHeaders(List.of(
-                "Location"
+                "Location",
+                "X-Trace-Id",
+                "X-Request-Id"
         ));
 
         // link configuration to all endpoints

--- a/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
+++ b/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
@@ -245,6 +245,25 @@ class ProblemDetailWebTest {
                 .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())));
     }
 
+    @Test
+    void badRequest_includesHeaders_noIncidentId() throws Exception {
+        var malformedJson = "{";
+        mvc.perform(post("/api/auth/register").contentType(MediaType.APPLICATION_JSON).content(malformedJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(header().string("X-Trace-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(jsonPath("$.incidentId").doesNotExist());
+    }
+
+    @Test
+    void unauthorized_includesHeaders_noIncidentId() throws Exception {
+        mvc.perform(get("/api/user/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string("X-Trace-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(jsonPath("$.incidentId").doesNotExist());
+    }
+
     @TestConfiguration
     @EnableConfigurationProperties(ProblemProperties.class)
     static class TestErrorConfig {

--- a/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
+++ b/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vire.virebackend.config.CorsProperties;
 import com.vire.virebackend.controller.AuthController;
 import com.vire.virebackend.controller.UserController;
-import com.vire.virebackend.entity.User;
 import com.vire.virebackend.entity.Role;
+import com.vire.virebackend.entity.User;
 import com.vire.virebackend.problem.ProblemFactory;
 import com.vire.virebackend.problem.ProblemProperties;
 import com.vire.virebackend.problem.ProblemTypeResolver;
@@ -18,6 +18,7 @@ import com.vire.virebackend.security.handler.SecurityProblemHandlers;
 import com.vire.virebackend.service.AuthService;
 import com.vire.virebackend.service.UserService;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -262,6 +263,38 @@ class ProblemDetailWebTest {
                 .andExpect(header().string("X-Trace-Id", Matchers.not(Matchers.isEmptyOrNullString())))
                 .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())))
                 .andExpect(jsonPath("$.incidentId").doesNotExist());
+    }
+
+    @Test
+    void forbidden_includesHeaders_noIncidentId() throws Exception {
+        mvc.perform(get("/api/test/admin-only").with(user("john").roles("USER")))
+                .andExpect(status().isForbidden())
+                .andExpect(header().string("X-Trace-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(jsonPath("$.incidentId").doesNotExist());
+    }
+
+    @Test
+    void notFound_includesHeaders_noIncidentId() throws Exception {
+        mvc.perform(get("/api/does-not-exist").with(user("john")))
+                .andExpect(status().isNotFound())
+                .andExpect(header().string("X-Trace-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(jsonPath("$.incidentId").doesNotExist());
+    }
+
+    @Test
+    void internalError_includesHeaders_andIncidentIdEqualsTraceId() throws Exception {
+        var result = mvc.perform(get("/api/test/error").with(user("john")))
+                .andExpect(status().isInternalServerError())
+                .andExpect(header().string("X-Trace-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andExpect(header().string("X-Request-Id", Matchers.not(Matchers.isEmptyOrNullString())))
+                .andReturn();
+
+        var xTraceId = result.getResponse().getHeader("X-Trace-Id");
+        var body = result.getResponse().getContentAsString();
+        var node = om.readTree(body);
+        Assertions.assertEquals(xTraceId, node.get("incidentId").asText());
     }
 
     @TestConfiguration


### PR DESCRIPTION
## What’s Changed

- Use MCD values in FallbackExceptionHandler
- Expose X-Trace-Id and X-Request-Id in headers
- Add tests
  - A successful 200 response includes X-Trace-Id and X-Request-Id.
  - A 400/401/403/404 response includes both headers but no incidentId field in the body.
  - A 500 response includes both headers and incidentId in the body (equal to X-Trace-Id).

## Why

- Consistent errors handling and tracking

## How to Test

1. Run tests in ProblemDetailWebTest

All tests should pass

## Additional Notes

- Closes #28
