### PR TITLE
Sessions/jti logout 36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/vire/virebackend/ViReBackendApplication.java
+++ b/src/main/java/com/vire/virebackend/ViReBackendApplication.java
@@ -2,13 +2,19 @@ package com.vire.virebackend;
 
 import com.vire.virebackend.config.CorsProperties;
 import com.vire.virebackend.config.JwtProperties;
+import com.vire.virebackend.config.SessionProperties;
 import com.vire.virebackend.problem.ProblemProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({JwtProperties.class, ProblemProperties.class, CorsProperties.class})
+@EnableConfigurationProperties({
+        JwtProperties.class,
+        ProblemProperties.class,
+        CorsProperties.class,
+        SessionProperties.class
+})
 public class ViReBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/vire/virebackend/config/SessionProperties.java
+++ b/src/main/java/com/vire/virebackend/config/SessionProperties.java
@@ -1,0 +1,17 @@
+package com.vire.virebackend.config;
+
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+@Validated
+@ConfigurationProperties(prefix = "session")
+public record SessionProperties(
+        @NotNull
+        @DurationMin(seconds = 1)
+        Duration activityUpdateThreshold
+) {
+}

--- a/src/main/java/com/vire/virebackend/controller/AuthController.java
+++ b/src/main/java/com/vire/virebackend/controller/AuthController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -16,10 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/auth")
@@ -60,5 +59,21 @@ public class AuthController {
         var response = authService.login(request, http);
         log.info("Login success: id={}", response.id());
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Logout current session")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("logout")
+    public ResponseEntity<Void> logout(@RequestHeader(value = "Authorization", required = false) String authorization) {
+        authService.logout(authorization);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Logout all user sessions")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("logout-all")
+    public ResponseEntity<Void> logoutAll(Authentication authentication) {
+        authService.logoutAll(authentication);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/vire/virebackend/controller/AuthController.java
+++ b/src/main/java/com/vire/virebackend/controller/AuthController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,9 +40,9 @@ public class AuthController {
             }
     )
     @PostMapping("register")
-    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request, HttpServletRequest http) {
         log.info("Registration attempt: email={}", request.email());
-        var response = authService.register(request);
+        var response = authService.register(request, http);
         log.info("Registration success: id={}", response.id());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -54,9 +55,9 @@ public class AuthController {
             }
     )
     @PostMapping("login")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request, HttpServletRequest http) {
         log.info("Login attempt: email={}", request.email());
-        var response = authService.login(request);
+        var response = authService.login(request, http);
         log.info("Login success: id={}", response.id());
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/vire/virebackend/entity/Session.java
+++ b/src/main/java/com/vire/virebackend/entity/Session.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -31,4 +32,13 @@ public class Session extends BaseEntity {
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
+
+    @Column(name = "jti", nullable = false, unique = true)
+    private UUID jti;
+
+    @Column(name = "user_agent")
+    private String userAgent;
+
+    @Column(name = "last_activity_at")
+    private LocalDateTime lastActivityAt;
 }

--- a/src/main/java/com/vire/virebackend/repository/SessionRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/SessionRepository.java
@@ -14,4 +14,6 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
     List<Session> findAllByUserIdOrderByCreatedAtDesc(UUID userId);
 
     Optional<Session> findByIdAndUserId(UUID id, UUID userId);
+
+    Optional<Session> findByJtiAndIsActive(UUID jti, boolean isActive);
 }

--- a/src/main/java/com/vire/virebackend/repository/SessionRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/SessionRepository.java
@@ -16,4 +16,6 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
     Optional<Session> findByIdAndUserId(UUID id, UUID userId);
 
     Optional<Session> findByJtiAndIsActive(UUID jti, boolean isActive);
+
+    List<Session> findAllByUserIdAndIsActiveTrue(UUID userId);
 }

--- a/src/main/java/com/vire/virebackend/security/JwtService.java
+++ b/src/main/java/com/vire/virebackend/security/JwtService.java
@@ -24,9 +24,10 @@ public class JwtService {
         return Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(User user) {
+    public String generateToken(User user, UUID jti) {
         return Jwts.builder()
                 .subject(user.getId().toString())
+                .id(jti.toString())
                 .claim("roles", user.getRoles().stream().map(Role::getName).toList())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().toMillis()))
@@ -56,5 +57,9 @@ public class JwtService {
 
     public Boolean isTokenExpired(String token) {
         return extractAllClaims(token).getExpiration().before(new Date());
+    }
+
+    public UUID extractJti(String token) {
+        return UUID.fromString(extractAllClaims(token).getId());
     }
 }

--- a/src/main/java/com/vire/virebackend/security/SessionActivityTracker.java
+++ b/src/main/java/com/vire/virebackend/security/SessionActivityTracker.java
@@ -1,0 +1,24 @@
+package com.vire.virebackend.security;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SessionActivityTracker {
+    private final Map<UUID, Instant> lastWriteByJti = new ConcurrentHashMap<>();
+
+    public Boolean shouldUpdate(UUID jti, Duration threshold) {
+        var now = Instant.now();
+        var last = lastWriteByJti.get(jti);
+        if (last == null || Duration.between(last, now).compareTo(threshold) >= 0) {
+            lastWriteByJti.put(jti, now);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/vire/virebackend/service/AuthService.java
+++ b/src/main/java/com/vire/virebackend/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.vire.virebackend.service;
 
+import com.vire.virebackend.config.JwtProperties;
 import com.vire.virebackend.dto.auth.LoginRequest;
 import com.vire.virebackend.dto.auth.LoginResponse;
 import com.vire.virebackend.dto.auth.RegisterRequest;
@@ -33,6 +34,7 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final RoleRepository roleRepository;
     private final SessionRepository sessionRepository;
+    private final JwtProperties jwtProperties;
 
     @Transactional
     public RegisterResponse register(RegisterRequest request, HttpServletRequest http) {
@@ -59,7 +61,7 @@ public class AuthService {
                 .ip(http.getRemoteAddr())
                 .deviceName("Unknown device") // todo: determine by User-Agent
                 .lastActivityAt(LocalDateTime.now())
-                .expiresAt(LocalDateTime.now().plusDays(30))
+                .expiresAt(LocalDateTime.now().plus(jwtProperties.expiration()))
                 .build();
 
         sessionRepository.save(session);
@@ -88,7 +90,7 @@ public class AuthService {
                 .ip(http.getRemoteAddr())
                 .deviceName("Unknown device") // todo: determine by User-Agent
                 .lastActivityAt(LocalDateTime.now())
-                .expiresAt(LocalDateTime.now().plusDays(30))
+                .expiresAt(LocalDateTime.now().plus(jwtProperties.expiration()))
                 .build();
 
         sessionRepository.save(session);

--- a/src/main/java/com/vire/virebackend/service/SessionService.java
+++ b/src/main/java/com/vire/virebackend/service/SessionService.java
@@ -1,5 +1,6 @@
 package com.vire.virebackend.service;
 
+import com.vire.virebackend.config.JwtProperties;
 import com.vire.virebackend.dto.session.CreateSessionRequest;
 import com.vire.virebackend.dto.session.SessionDto;
 import com.vire.virebackend.entity.Session;
@@ -24,6 +25,7 @@ public class SessionService {
 
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
+    private final JwtProperties jwtProperties;
 
     @Transactional
     public SessionDto createSession(Authentication auth, CreateSessionRequest request, HttpServletRequest http) {
@@ -40,7 +42,7 @@ public class SessionService {
                 .user(user)
                 .deviceName(deviceName)
                 .ip(ip)
-                .expiresAt(LocalDateTime.now().plusDays(30))
+                .expiresAt(LocalDateTime.now().plus(jwtProperties.expiration()))
                 .isActive(true)
                 .build();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,9 @@ management:
 problem:
   base-uri: https://vire.dev/problems/
 
+session:
+  activity-update-threshold: 5m
+
 springdoc:
   swagger-ui:
     display-request-duration: true

--- a/src/main/resources/db/changelog/11-jti-user-agent-sessions.yaml
+++ b/src/main/resources/db/changelog/11-jti-user-agent-sessions.yaml
@@ -1,0 +1,39 @@
+databaseChangeLog:
+  - changeSet:
+      id: 11-jti-user-agent-sessions
+      author: vladead
+      changes:
+        - addColumn:
+            tableName: sessions
+            columns:
+              - column:
+                  name: jti
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_agent
+                  type: varchar(255)
+              - column:
+                  name: last_activity_at
+                  type: timestamp
+        - createIndex:
+            tableName: sessions
+            indexName: idx_sessions_jti
+            unique: true
+            columns:
+              - column:
+                  name: jti
+      rollback:
+        - dropIndex:
+            indexName: idx_sessions_jti
+            tableName: sessions
+        - dropColumn:
+            tableName: sessions
+            columnName: last_activity_at
+        - dropColumn:
+            tableName: sessions
+            columnName: user_agent
+        - dropColumn:
+            tableName: sessions
+            columnName: jti

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       file: 10-create-user-plans-table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 11-jti-user-agent-sessions.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/vire/virebackend/ViReBackendApplicationTests.java
+++ b/src/test/java/com/vire/virebackend/ViReBackendApplicationTests.java
@@ -3,7 +3,17 @@ package com.vire.virebackend;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.liquibase.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=none",
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "jwt.secret=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "jwt.expiration=1h",
+        "session.activity-update-threshold=5m"
+})
 class ViReBackendApplicationTests {
 
     @Test

--- a/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
+++ b/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
@@ -2,6 +2,7 @@ package com.vire.virebackend.controller.advice;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vire.virebackend.config.CorsProperties;
+import com.vire.virebackend.config.SessionProperties;
 import com.vire.virebackend.controller.AuthController;
 import com.vire.virebackend.controller.UserController;
 import com.vire.virebackend.entity.Role;
@@ -9,13 +10,16 @@ import com.vire.virebackend.entity.User;
 import com.vire.virebackend.problem.ProblemFactory;
 import com.vire.virebackend.problem.ProblemProperties;
 import com.vire.virebackend.problem.ProblemTypeResolver;
+import com.vire.virebackend.repository.SessionRepository;
 import com.vire.virebackend.repository.UserRepository;
 import com.vire.virebackend.security.JwtService;
 import com.vire.virebackend.security.SecurityConfig;
+import com.vire.virebackend.security.SessionActivityTracker;
 import com.vire.virebackend.security.filter.JwtAuthenticationFilter;
 import com.vire.virebackend.security.filter.MdcLoggingFilter;
 import com.vire.virebackend.security.handler.SecurityProblemHandlers;
 import com.vire.virebackend.service.AuthService;
+import com.vire.virebackend.service.UserPlanService;
 import com.vire.virebackend.service.UserService;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -71,7 +75,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "jwt.secret=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "jwt.expiration=1h",
-        "spring.mvc.problemdetails.enabled=true"
+        "spring.mvc.problemdetails.enabled=true",
+        "session.activity-update-threshold=5m"
 })
 class ProblemDetailWebTest {
 
@@ -89,6 +94,15 @@ class ProblemDetailWebTest {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    SessionRepository sessionRepository;
+
+    @Autowired
+    SessionActivityTracker sessionActivityTracker;
+
+    @Autowired
+    SessionProperties sessionProperties;
 
     @Test
     void register_invalidPayload_returns400_problemDetail() throws Exception {
@@ -162,6 +176,8 @@ class ProblemDetailWebTest {
         var token = "valid_jwt_token";
 
         Mockito.when(jwtService.extractUserId(token)).thenReturn(userId);
+        var jti = UUID.randomUUID();
+        Mockito.when(jwtService.extractJti(token)).thenReturn(jti);
 
         var user = User.builder()
                 .username("john")
@@ -173,6 +189,8 @@ class ProblemDetailWebTest {
         user.getRoles().add(role);
         Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         Mockito.when(jwtService.isTokenValid(token, user)).thenReturn(true);
+        Mockito.when(sessionRepository.findByJtiAndIsActive(jti, true)).thenReturn(java.util.Optional.of(new com.vire.virebackend.entity.Session()));
+        Mockito.when(sessionActivityTracker.shouldUpdate(Mockito.eq(jti), Mockito.any())).thenReturn(false);
 
         mvc.perform(get("/api/user/me").header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -229,6 +247,8 @@ class ProblemDetailWebTest {
         var token = "valid_jwt_token";
 
         Mockito.when(jwtService.extractUserId(token)).thenReturn(userId);
+        var jti = UUID.randomUUID();
+        Mockito.when(jwtService.extractJti(token)).thenReturn(jti);
         var user = User.builder()
                 .username("john")
                 .email("john@example.com")
@@ -239,6 +259,8 @@ class ProblemDetailWebTest {
         user.getRoles().add(role);
         Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         Mockito.when(jwtService.isTokenValid(token, user)).thenReturn(true);
+        Mockito.when(sessionRepository.findByJtiAndIsActive(jti, true)).thenReturn(java.util.Optional.of(new com.vire.virebackend.entity.Session()));
+        Mockito.when(sessionActivityTracker.shouldUpdate(Mockito.eq(jti), Mockito.any())).thenReturn(false);
 
         mvc.perform(get("/api/user/me").header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -321,26 +343,51 @@ class ProblemDetailWebTest {
         }
 
         @Bean
-        com.vire.virebackend.service.UserPlanService userPlanService() {
-            return Mockito.mock(com.vire.virebackend.service.UserPlanService.class);
+        UserPlanService userPlanService() {
+            return Mockito.mock(UserPlanService.class);
         }
 
         @Bean
-        com.vire.virebackend.security.JwtService jwtService() {
+        JwtService jwtService() {
             return Mockito.mock(JwtService.class);
         }
 
         @Bean
-        com.vire.virebackend.repository.UserRepository userRepository() {
+        UserRepository userRepository() {
             return Mockito.mock(UserRepository.class);
+        }
+
+        @Bean
+        SessionRepository sessionRepository() {
+            return Mockito.mock(SessionRepository.class);
+        }
+
+        @Bean
+        SessionActivityTracker sessionActivityTracker() {
+            return Mockito.mock(SessionActivityTracker.class);
+        }
+
+        @Bean
+        SessionProperties sessionProperties() {
+            // вернуть реальный бин со значением, чтобы прошла валидация @ConfigurationProperties
+            return new SessionProperties(java.time.Duration.ofMinutes(5));
         }
 
         @Bean
         JwtAuthenticationFilter jwtAuthenticationFilter(
                 JwtService jwtService,
-                UserRepository userRepository
+                UserRepository userRepository,
+                SessionRepository sessionRepository,
+                SessionActivityTracker sessionActivityTracker,
+                SessionProperties sessionProperties
         ) {
-            return new JwtAuthenticationFilter(jwtService, userRepository);
+            return new JwtAuthenticationFilter(
+                    jwtService,
+                    userRepository,
+                    sessionRepository,
+                    sessionActivityTracker,
+                    sessionProperties
+            );
         }
 
         @Bean

--- a/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
+++ b/src/test/java/com/vire/virebackend/controller/advice/ProblemDetailWebTest.java
@@ -126,7 +126,7 @@ class ProblemDetailWebTest {
                 "password", "wrongpass"
         );
 
-        Mockito.when(authService.login(Mockito.any()))
+        Mockito.when(authService.login(Mockito.any(), Mockito.any()))
                 .thenThrow(new BadCredentialsException("Bad creds"));
 
         mvc.perform(post("/api/auth/login")
@@ -146,7 +146,7 @@ class ProblemDetailWebTest {
                 "password", "12345678"
         );
 
-        Mockito.when(authService.register(Mockito.any()))
+        Mockito.when(authService.register(Mockito.any(), Mockito.any()))
                 .thenThrow(new DataIntegrityViolationException("duplicate"));
 
         mvc.perform(post("/api/auth/register")

--- a/src/test/java/com/vire/virebackend/service/AuthServiceTest.java
+++ b/src/test/java/com/vire/virebackend/service/AuthServiceTest.java
@@ -1,9 +1,14 @@
 package com.vire.virebackend.service;
 
 import com.vire.virebackend.dto.auth.RegisterRequest;
+import com.vire.virebackend.entity.Role;
+import com.vire.virebackend.entity.Session;
 import com.vire.virebackend.entity.User;
+import com.vire.virebackend.repository.RoleRepository;
+import com.vire.virebackend.repository.SessionRepository;
 import com.vire.virebackend.repository.UserRepository;
 import com.vire.virebackend.security.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,10 +19,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
@@ -30,6 +37,10 @@ public class AuthServiceTest {
     private PasswordEncoder passwordEncoder;
     @Mock
     private AuthenticationManager authenticationManager;
+    @Mock
+    private RoleRepository roleRepository;
+    @Mock
+    private SessionRepository sessionRepository;
 
     @InjectMocks
     private AuthService authService;
@@ -42,36 +53,53 @@ public class AuthServiceTest {
     }
 
     @Test
-    void register_shouldSaveUserAndReturnToken() {
+    void register_shouldSaveUser_issueJwtWithJti_andCreateServerSession() {
+        // arrange
+        var http = mock(HttpServletRequest.class);
+        when(http.getHeader("User-Agent")).thenReturn("JUnit/Mockito UA");
+        when(http.getRemoteAddr()).thenReturn("127.0.0.1");
+
         var encoded = "EncodedPassword";
         when(passwordEncoder.encode(request.password())).thenReturn(encoded);
 
-        // userRepository.save() should return object with generated id
-        var savedUser = User.builder()
-                .username(request.username())
-                .email(request.email())
-                .password(encoded)
-                .build();
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        var role = new Role();
+        role.setName("USER");
+        when(roleRepository.findByName("USER")).thenReturn(Optional.of(role));
+
+        // userRepository.save returns the same instance (id may be null in unit test)
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // sessionRepository.save returns the same session
+        when(sessionRepository.save(any(Session.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         var expectedToken = "jwt-token";
-        when(jwtService.generateToken(any(User.class))).thenReturn(expectedToken);
+        when(jwtService.generateToken(any(User.class), any(UUID.class))).thenReturn(expectedToken);
 
-        // when
-        var response = authService.register(request);
+        // act
+        var response = authService.register(request, http);
 
-        // then
-        // check saving user with encoded password
+        // assert: user saved with encoded password
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
-        User captured = userCaptor.getValue();
-        assertThat(captured.getPassword()).isEqualTo(encoded);
+        var savedUser = userCaptor.getValue();
+        assertThat(savedUser.getPassword()).isEqualTo(encoded);
+        assertThat(savedUser.getRoles()).extracting("name").contains("USER");
 
-        // check token generation
-        verify(jwtService).generateToken(captured);
+        // assert: session saved with non-null jti and active
+        ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionRepository).save(sessionCaptor.capture());
+        var savedSession = sessionCaptor.getValue();
+        assertThat(savedSession.getUser()).isEqualTo(savedUser);
+        assertThat(savedSession.getJti()).isNotNull();
+        assertThat(savedSession.getIsActive()).isTrue();
+        assertThat(savedSession.getUserAgent()).isEqualTo("JUnit/Mockito UA");
+        assertThat(savedSession.getIp()).isEqualTo("127.0.0.1");
 
-        // check method result
-        assertThat(response.id()).isEqualTo(savedUser.getId());
+        // assert: jwt issued with the same jti
+        ArgumentCaptor<UUID> jtiCaptor = ArgumentCaptor.forClass(UUID.class);
+        verify(jwtService).generateToken(eq(savedUser), jtiCaptor.capture());
+        assertThat(jtiCaptor.getValue()).isEqualTo(savedSession.getJti());
+
+        // assert: response contains token
         assertThat(response.token()).isEqualTo(expectedToken);
     }
 }


### PR DESCRIPTION
## What’s Changed

- Update Session entity and prepare db migrations
- Generate jti and set it in token
- Add throttle lastActivityAt
- Sync ttl of session and token

## Why

To introduce manageable, server-side sessions while keeping stateless JWTs: a token is valid only if its server session is active

## How to Test

1. Start app
2. Login as some user
3. List sessions to ensure session ttl

## Additional Notes

- Closes #36
