### PR TITLE
Roles management

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -1,12 +1,14 @@
 package com.vire.virebackend.controller;
 
 import com.vire.virebackend.dto.PageResponse;
+import com.vire.virebackend.dto.admin.user.UpdateUserRolesRequest;
 import com.vire.virebackend.dto.admin.user.UserSummaryDto;
 import com.vire.virebackend.dto.admin.user.UserSummarySubscriptionSessionDto;
 import com.vire.virebackend.dto.plan.CreatePlanRequest;
 import com.vire.virebackend.dto.plan.PlanDto;
 import com.vire.virebackend.dto.plan.UpdatePlanRequest;
 import com.vire.virebackend.mapper.PageResponseMapper;
+import com.vire.virebackend.security.CustomUserDetails;
 import com.vire.virebackend.service.AdminService;
 import com.vire.virebackend.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -49,6 +52,17 @@ public class AdminController {
     @GetMapping("users/{id}")
     public ResponseEntity<UserSummarySubscriptionSessionDto> getUserProfile(@PathVariable UUID id) {
         return ResponseEntity.ok(adminService.getProfile(id));
+    }
+
+    @Operation(summary = "Update user roles (whitelist via DB: USER, ADMIN). Idempotent")
+    @PutMapping("users/{id}/roles")
+    public ResponseEntity<UserSummaryDto> updateUserRoles(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateUserRolesRequest request,
+            @AuthenticationPrincipal CustomUserDetails current
+    ) {
+        var updated = adminService.updateUserRoles(id, request.roles(), current.getUser().getId());
+        return ResponseEntity.ok(updated);
     }
 
     @Operation(summary = "Create a new plan")

--- a/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/vire/virebackend/controller/advice/GlobalExceptionHandler.java
@@ -55,6 +55,12 @@ public class GlobalExceptionHandler {
         return problemFactory.badRequest("Malformed or invalid request");
     }
 
+    // 400 invalid arguments in service layer
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(IllegalArgumentException exception) {
+        return problemFactory.badRequest(exception.getMessage());
+    }
+
     // 401 authentication failures outside Security Filter (e.g. wrong password)
     @ExceptionHandler(AuthenticationException.class)
     public ProblemDetail handleAuth(AuthenticationException exception, HttpServletResponse response) {

--- a/src/main/java/com/vire/virebackend/dto/admin/user/UpdateUserRolesRequest.java
+++ b/src/main/java/com/vire/virebackend/dto/admin/user/UpdateUserRolesRequest.java
@@ -1,0 +1,13 @@
+package com.vire.virebackend.dto.admin.user;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UpdateUserRolesRequest(
+        @JsonProperty("roles")
+        @NotNull
+        List<String> roles
+) {
+}

--- a/src/main/java/com/vire/virebackend/repository/RoleRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/RoleRepository.java
@@ -4,6 +4,8 @@ import com.vire.virebackend.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +13,6 @@ import java.util.UUID;
 public interface RoleRepository extends JpaRepository<Role, UUID> {
 
     Optional<Role> findByName(String name);
+
+    List<Role> findByNameIn(Collection<String> names);
 }

--- a/src/main/java/com/vire/virebackend/repository/UserRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByUsername(String username);
+
+    Long countByRoles_Name(String roleName);
 }


### PR DESCRIPTION
## What’s Changed

- Added idempotent PUT /api/admin/users/{id}/roles
- Enforced role whitelist via DB lookup (roles table, findByNameIn)
- Guardrails: prevent self-demotion (cannot remove own ADMIN), prevent zero-admin system
- Repositories: UserRepository.countByRoles_Name, RoleRepository.findByNameIn
- Global 400 handling for IllegalArgumentException in GlobalExceptionHandler

## Why

- Provide a safe admin flow to assign roles from a whitelist (USER, ADMIN)
- Prevent accidental admin lockout (self-demotion, last admin removal)
- Ensure idempotent updates for repeated requests

## How to Test

- Idempotency
  - PUT /api/admin/users/{id}/roles with {"roles":["USER","ADMIN"]} twice
  - Expect: 200 OK both times; no changes on the second call
- Demote another admin (when ≥2 admins exist)
  - PUT with {"roles":["USER"]} for another admin user
  - Expect: 200 OK; target user loses ADMIN
- Self-demotion
  - As ADMIN, PUT for your own {id} with {"roles":["USER"]}
  - Expect: 403 Forbidden
- Last admin protection
  - If only one ADMIN exists, try {"roles":["USER"]} on that user
  - Expect: 403 Forbidden
- Unknown role
  - PUT {"roles":["USER","SUPERADMIN"]}
  - Expect: 400 Bad Request (Problem Details with unknown roles)

## Additional Notes

- Closes #38 
