### PR TITLE
Terminate user sessions 39

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -7,6 +7,7 @@ import com.vire.virebackend.dto.admin.user.UserSummarySubscriptionSessionDto;
 import com.vire.virebackend.dto.plan.CreatePlanRequest;
 import com.vire.virebackend.dto.plan.PlanDto;
 import com.vire.virebackend.dto.plan.UpdatePlanRequest;
+import com.vire.virebackend.dto.session.DeactivateSessionResponse;
 import com.vire.virebackend.mapper.PageResponseMapper;
 import com.vire.virebackend.security.CustomUserDetails;
 import com.vire.virebackend.service.AdminService;
@@ -25,6 +26,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -65,6 +67,25 @@ public class AdminController {
         return ResponseEntity.ok(updated);
     }
 
+    @Operation(summary = "Terminate a specific user session")
+    @DeleteMapping("users/{id}/sessions/{sessionId}")
+    public ResponseEntity<DeactivateSessionResponse> terminateUserSession(
+            @PathVariable UUID id,
+            @PathVariable UUID sessionId
+    ) {
+        var response = adminService.deactivateSession(id, sessionId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Logout user from all devices")
+    @PostMapping("users/{id}/logout-all")
+    public ResponseEntity<List<DeactivateSessionResponse>> logoutAllUserSessions(
+            @PathVariable UUID id
+    ) {
+        var response = adminService.logoutAllUserSessions(id);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "Create a new plan")
     @PostMapping("plans")
     public ResponseEntity<PlanDto> create(@Valid @RequestBody CreatePlanRequest request) {
@@ -87,5 +108,4 @@ public class AdminController {
     ) {
         return ResponseEntity.ok(planService.updatePlan(request, id));
     }
-
 }

--- a/src/main/java/com/vire/virebackend/dto/session/DeactivateSessionResponse.java
+++ b/src/main/java/com/vire/virebackend/dto/session/DeactivateSessionResponse.java
@@ -1,0 +1,16 @@
+package com.vire.virebackend.dto.session;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record DeactivateSessionResponse(
+        @JsonProperty("id")
+        UUID id,
+
+        @JsonProperty("was_active")
+        Boolean wasActive
+) {
+}

--- a/src/main/java/com/vire/virebackend/service/AdminService.java
+++ b/src/main/java/com/vire/virebackend/service/AdminService.java
@@ -117,7 +117,7 @@ public class AdminService {
 
     @Transactional
     public DeactivateSessionResponse deactivateSession(UUID userId, UUID sessionId) {
-        var session = sessionRepository.findById(sessionId)
+        var session = sessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(EntityNotFoundException::new);
 
         var wasActive = session.getIsActive();


### PR DESCRIPTION
## What’s Changed

- Add admin endpoint DELETE /api/admin/users/{id}/sessions/{sessionId} to deactivate a specific session
- Add admin endpoint POST /api/admin/users/{id}/logout-all to deactivate all sessions of a user
- Implement AdminService methods to perform deactivation and return minimal response

## Why

- Allow administrators to terminate problematic sessions or log a user out from all devices, improving security and incident response
- Provide minimal, idempotent responses indicating whether a session was active before the operation

## How to Test

- DELETE a specific session:
  - Request: DELETE /api/admin/users/{userId}/sessions/{sessionId} (as ADMIN)
  - Expected: 200 OK with body like {"id":"<sessionId>","was_active":true|false}; the session becomes inactive
- POST logout-all for a user:
  - Request: POST /api/admin/users/{userId}/logout-all (as ADMIN)
  - Expected: 200 OK with body as a list of {"id","was_active"}; all active sessions become inactive

## Additional Notes

- Closes #39
