### PR TITLE
Plans admin management 41

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -7,6 +7,7 @@ import com.vire.virebackend.dto.admin.user.UserSummarySubscriptionSessionDto;
 import com.vire.virebackend.dto.plan.CreatePlanRequest;
 import com.vire.virebackend.dto.plan.PlanDto;
 import com.vire.virebackend.dto.plan.UpdatePlanRequest;
+import com.vire.virebackend.dto.plan.UserPlanDto;
 import com.vire.virebackend.dto.session.DeactivateSessionResponse;
 import com.vire.virebackend.mapper.PageResponseMapper;
 import com.vire.virebackend.security.CustomUserDetails;
@@ -42,8 +43,7 @@ public class AdminController {
     @Operation(summary = "List users (paginated, createdAt DESC by default)")
     @GetMapping("users")
     public PageResponse<UserSummaryDto> listUsers(
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             HttpServletRequest request
     ) {
         var page = adminService.listUsers(pageable);
@@ -65,6 +65,17 @@ public class AdminController {
     ) {
         var updated = adminService.updateUserRoles(id, request.roles(), current.getUser().getId());
         return ResponseEntity.ok(updated);
+    }
+
+    @Operation(summary = "List user plan history")
+    @GetMapping("users/{id}/plans")
+    public PageResponse<UserPlanDto> listUserPlans(
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable UUID id,
+            HttpServletRequest request
+    ) {
+        var page = adminService.listUserPlans(id, pageable);
+        return PageResponseMapper.toResponse(page, request);
     }
 
     @Operation(summary = "Terminate a specific user session")

--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -108,4 +108,10 @@ public class AdminController {
     ) {
         return ResponseEntity.ok(planService.updatePlan(request, id));
     }
+
+    @Operation(summary = "List all plans")
+    @GetMapping("plans")
+    public List<PlanDto> getAllPlans() {
+        return planService.getAllPlans();
+    }
 }

--- a/src/main/java/com/vire/virebackend/repository/UserPlanRepository.java
+++ b/src/main/java/com/vire/virebackend/repository/UserPlanRepository.java
@@ -1,6 +1,8 @@
 package com.vire.virebackend.repository;
 
 import com.vire.virebackend.entity.UserPlan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +17,6 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, UUID> {
     List<UserPlan> findByUserIdOrderByStartDateDesc(UUID userId);
 
     Optional<UserPlan> findFirstByUserIdAndEndDateAfterOrderByEndDateDesc(UUID userId, LocalDateTime now);
+
+    Page<UserPlan> findByUserIdOrderByStartDateDesc(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/vire/virebackend/service/AdminService.java
+++ b/src/main/java/com/vire/virebackend/service/AdminService.java
@@ -3,8 +3,10 @@ package com.vire.virebackend.service;
 import com.vire.virebackend.dto.admin.session.SessionSummaryDto;
 import com.vire.virebackend.dto.admin.user.UserSummaryDto;
 import com.vire.virebackend.dto.admin.user.UserSummarySubscriptionSessionDto;
+import com.vire.virebackend.dto.plan.UserPlanDto;
 import com.vire.virebackend.dto.session.DeactivateSessionResponse;
 import com.vire.virebackend.entity.Role;
+import com.vire.virebackend.mapper.UserPlanMapper;
 import com.vire.virebackend.mapper.admin.plan.UserPlanSummaryMapper;
 import com.vire.virebackend.mapper.admin.session.SessionSummaryMapper;
 import com.vire.virebackend.mapper.admin.user.UserSummaryMapper;
@@ -154,5 +156,11 @@ public class AdminService {
             sessionRepository.saveAll(allSessions);
         }
         return responses;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserPlanDto> listUserPlans(UUID userId, Pageable pageable) {
+        var userPlans = userPlanRepository.findByUserIdOrderByStartDateDesc(userId, pageable);
+        return userPlans.map(UserPlanMapper::toDto);
     }
 }


### PR DESCRIPTION
## What’s Changed

- Add admin endpoint GET /api/admin/plans to list all plans
- Add admin endpoint GET /api/admin/users/{id}/plans to list a user’s subscription history (paginated)
- Return paginated responses via PageResponse (items + meta)

## Why

- Provide admins with visibility into plans and users’ subscription history
- Enable basic plan management and subscription auditing from the admin view

## How to Test

- List plans (admin only):
  - Request: GET /api/admin/plans
  - Expected: 200 OK with List<PlanDto>
- List a user’s subscriptions (admin only, paginated):
  - Request: GET /api/admin/users/{userId}/plans?page=0&size=20
  - Expected: 200 OK with PageResponse<UserPlanDto> (items + pagination meta)

## Additional Notes

- Closes #41
