### PR TITLE
Observability 43

### DIFF
--- a/src/main/java/com/vire/virebackend/controller/AdminController.java
+++ b/src/main/java/com/vire/virebackend/controller/AdminController.java
@@ -82,18 +82,20 @@ public class AdminController {
     @DeleteMapping("users/{id}/sessions/{sessionId}")
     public ResponseEntity<DeactivateSessionResponse> terminateUserSession(
             @PathVariable UUID id,
-            @PathVariable UUID sessionId
+            @PathVariable UUID sessionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser
     ) {
-        var response = adminService.deactivateSession(id, sessionId);
+        var response = adminService.deactivateSession(id, sessionId, currentUser.getUser().getId());
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "Logout user from all devices")
     @PostMapping("users/{id}/logout-all")
     public ResponseEntity<List<DeactivateSessionResponse>> logoutAllUserSessions(
-            @PathVariable UUID id
+            @PathVariable UUID id,
+            @AuthenticationPrincipal CustomUserDetails currentUser
     ) {
-        var response = adminService.logoutAllUserSessions(id);
+        var response = adminService.logoutAllUserSessions(id, currentUser.getUser().getId());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/vire/virebackend/service/AdminService.java
+++ b/src/main/java/com/vire/virebackend/service/AdminService.java
@@ -123,7 +123,7 @@ public class AdminService {
     }
 
     @Transactional
-    public DeactivateSessionResponse deactivateSession(UUID userId, UUID sessionId) {
+    public DeactivateSessionResponse deactivateSession(UUID userId, UUID sessionId, UUID actorUserId) {
         var session = sessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(EntityNotFoundException::new);
 
@@ -132,6 +132,9 @@ public class AdminService {
             session.setIsActive(false);
         }
 
+        log.info("Admin session termination: actorUserId={}, targetUserId={}, sessionId={}, wasActive={}",
+                actorUserId, userId, sessionId, wasActive);
+
         return DeactivateSessionResponse.builder()
                 .id(sessionId)
                 .wasActive(wasActive)
@@ -139,7 +142,7 @@ public class AdminService {
     }
 
     @Transactional
-    public List<DeactivateSessionResponse> logoutAllUserSessions(UUID userId) {
+    public List<DeactivateSessionResponse> logoutAllUserSessions(UUID userId, UUID actorUserId) {
         var allSessions = sessionRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
 
         var responses = new ArrayList<DeactivateSessionResponse>(allSessions.size());
@@ -160,6 +163,10 @@ public class AdminService {
         if (changed) {
             sessionRepository.saveAll(allSessions);
         }
+
+        log.info("Admin logout-all: actorUserId={}, targetUserId={}, totalSessions={}, changed={}",
+                actorUserId, userId, allSessions.size(), changed);
+
         return responses;
     }
 

--- a/src/main/java/com/vire/virebackend/service/AdminService.java
+++ b/src/main/java/com/vire/virebackend/service/AdminService.java
@@ -17,6 +17,7 @@ import com.vire.virebackend.repository.UserPlanRepository;
 import com.vire.virebackend.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminService {
 
     private final UserRepository userRepository;
@@ -113,6 +115,9 @@ public class AdminService {
 
         user.getRoles().clear();
         user.getRoles().addAll(new HashSet<>(roles));
+
+        log.info("Admin roles update: actorUserId={}, targetUserId={}, newRoles={}",
+                actorUserId, targetUserId, requested);
 
         return UserSummaryMapper.toDto(user);
     }


### PR DESCRIPTION
## What’s Changed

- Added INFO-level audit logs in AdminService for:
  - Role updates: actor, target user, new roles
  - Single session termination: actor, target user, sessionId, wasActive
  - Logout-all: actor, target user, totalSessions, changed
- Correlation IDs flow in logs via MDC (traceId, requestId)

## Why

- Improve traceability and accountability for admin operations

## How to Test

- Start the app
- Update roles:
  - curl -X PUT http://localhost:8080/api/admin/users/{userId}/roles -H "Authorization: Bearer $ADMIN_JWT" -H "Content-Type: application/json" -d '{"roles":["ADMIN","USER"]}'
- Terminate session:
  - curl -X DELETE http://localhost:8080/api/admin/users/{userId}/sessions/{sessionId} -H "Authorization: Bearer $ADMIN_JWT"
- Logout all:
  - curl -X POST http://localhost:8080/api/admin/users/{userId}/logout-all -H "Authorization: Bearer $ADMIN_JWT"
- Expected: INFO log lines with actorUserId, targetUserId, sessionId/all, and MDC prefix [traceId=...,requestId=...]

## Additional Notes

- Closes #43 
